### PR TITLE
Check for ZFS datadir and change InnoDB settings

### DIFF
--- a/10.0/docker-entrypoint.sh
+++ b/10.0/docker-entrypoint.sh
@@ -8,7 +8,15 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# read DATADIR from the MySQL config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	
+	if [[ -n $(df -T |grep ${DATADIR::-1} |grep zfs) ]]; then
+		echo "Found ZFS on "${DATADIR::-1}" removing AIO and O_DIRECT modes for InnoDB"
+		cat >> /etc/mysql/conf.d/zfs.cnf <<-EOF
+			[mysqld]
+			innodb_doublewrite = false
+			innodb_use_native_aio = false
+			innodb_flush_method=fsync
+		EOF
+	fi
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'

--- a/10.0/docker-entrypoint.sh
+++ b/10.0/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$1" = 'mysqld' ]; then
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	if [[ -n $(df -T |grep ${DATADIR::-1} |grep zfs) ]]; then
 		echo "Found ZFS on "${DATADIR::-1}" removing AIO and O_DIRECT modes for InnoDB"
-		cat >> /etc/mysql/conf.d/zfs.cnf <<-EOF
+		cat > /etc/mysql/conf.d/zfs.cnf <<-EOF
 			[mysqld]
 			innodb_doublewrite = false
 			innodb_use_native_aio = false

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -8,7 +8,15 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# read DATADIR from the MySQL config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	
+	if [[ -n $(df -T |grep ${DATADIR::-1} |grep zfs) ]]; then
+		echo "Found ZFS on "${DATADIR::-1}" removing AIO and O_DIRECT modes for InnoDB"
+		cat >> /etc/mysql/conf.d/zfs.cnf <<-EOF
+			[mysqld]
+			innodb_doublewrite = false
+			innodb_use_native_aio = false
+			innodb_flush_method=fsync
+		EOF
+	fi
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$1" = 'mysqld' ]; then
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	if [[ -n $(df -T |grep ${DATADIR::-1} |grep zfs) ]]; then
 		echo "Found ZFS on "${DATADIR::-1}" removing AIO and O_DIRECT modes for InnoDB"
-		cat >> /etc/mysql/conf.d/zfs.cnf <<-EOF
+		cat > /etc/mysql/conf.d/zfs.cnf <<-EOF
 			[mysqld]
 			innodb_doublewrite = false
 			innodb_use_native_aio = false

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,15 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# read DATADIR from the MySQL config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	
+	if [[ -n $(df -T |grep ${DATADIR::-1} |grep zfs) ]]; then
+		echo "Found ZFS on "${DATADIR::-1}" removing AIO and O_DIRECT modes for InnoDB"
+		cat >> /etc/mysql/conf.d/zfs.cnf <<-EOF
+			[mysqld]
+			innodb_doublewrite = false
+			innodb_use_native_aio = false
+			innodb_flush_method=fsync
+		EOF
+	fi
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$1" = 'mysqld' ]; then
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	if [[ -n $(df -T |grep ${DATADIR::-1} |grep zfs) ]]; then
 		echo "Found ZFS on "${DATADIR::-1}" removing AIO and O_DIRECT modes for InnoDB"
-		cat >> /etc/mysql/conf.d/zfs.cnf <<-EOF
+		cat > /etc/mysql/conf.d/zfs.cnf <<-EOF
 			[mysqld]
 			innodb_doublewrite = false
 			innodb_use_native_aio = false


### PR DESCRIPTION
Check for ZFS datadir and change InnoDB settings

InnoDB defaults to using AIO and O_DIRECT modes on files in upstream my.cnf.

This modification adds a zfs.cnf overriding the defaults if we detect that the mount point is ZFS:

```dosini
[mysqld]
innodb_doublewrite = false
innodb_use_native_aio = false
innodb_flush_method=fsync
```