### PR TITLE
Add "pinning" to ensure we don't run into issues with mixed dependencies

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -9,7 +9,14 @@ RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 199369E5404BD5FC
 ENV MARIADB_MAJOR 10.0
 ENV MARIADB_VERSION 10.0.17+maria-1~wheezy
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list \
+	&& { \
+		echo 'Package: *'; \
+		echo 'Pin: release o=MariaDB'; \
+		echo 'Pin-Priority: 999'; \
+	} > /etc/apt/preferences.d/mariadb
+# add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
+#  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
 
 RUN apt-get update \
 	&& apt-get install -y \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -9,7 +9,14 @@ RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 199369E5404BD5FC
 ENV MARIADB_MAJOR 5.5
 ENV MARIADB_VERSION 5.5.42+maria-1~wheezy
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list \
+	&& { \
+		echo 'Package: *'; \
+		echo 'Pin: release o=MariaDB'; \
+		echo 'Pin-Priority: 999'; \
+	} > /etc/apt/preferences.d/mariadb
+# add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
+#  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
 
 RUN apt-get update \
 	&& apt-get install -y \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,7 +9,14 @@ RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 199369E5404BD5FC
 ENV MARIADB_MAJOR %%MARIADB_MAJOR%%
 ENV MARIADB_VERSION %%MARIADB_VERSION%%
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list \
+	&& { \
+		echo 'Package: *'; \
+		echo 'Pin: release o=MariaDB'; \
+		echo 'Pin-Priority: 999'; \
+	} > /etc/apt/preferences.d/mariadb
+# add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
+#  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
 
 RUN apt-get update \
 	&& apt-get install -y \


### PR DESCRIPTION
Specifically, one of the dependencies of mariadb-server has a newer version in `wheezy`, but the dependency in the package was `= 5.5.42+maria-1~wheezy`, meaning it just refused to install.  By pinning the "Origin: MariaDB" repo to be the highest priority, this dependency chain resolves itself properly.

```
libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
```