### PR TITLE
Update 10.0 to jessie

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM debian:wheezy
+FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
@@ -7,9 +7,9 @@ RUN groupadd -r mysql && useradd -r -g mysql mysql
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB
 
 ENV MARIADB_MAJOR 10.0
-ENV MARIADB_VERSION 10.0.20+maria-1~wheezy
+ENV MARIADB_VERSION 10.0.20+maria-1~jessie
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list \
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=MariaDB'; \
@@ -18,7 +18,11 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheez
 # add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
 #  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
 
-RUN apt-get update \
+RUN { \
+		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password password 'unused'; \
+		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
+	} | debconf-set-selections \
+	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -18,7 +18,11 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheez
 # add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
 #  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
 
-RUN apt-get update \
+RUN { \
+		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password password 'unused'; \
+		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
+	} | debconf-set-selections \
+	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM debian:wheezy
+FROM debian:%%SUITE%%
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
@@ -9,7 +9,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD
 ENV MARIADB_MAJOR %%MARIADB_MAJOR%%
 ENV MARIADB_VERSION %%MARIADB_VERSION%%
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheezy main" > /etc/apt/sources.list.d/mariadb.list \
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian %%SUITE%% main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=MariaDB'; \
@@ -18,7 +18,11 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheez
 # add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
 #  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
 
-RUN apt-get update \
+RUN { \
+		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password password 'unused'; \
+		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
+	} | debconf-set-selections \
+	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+declare -A suites=(
+	[5.5]='wheezy'
+)
+defaultSuite='jessie'
+
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( "$@" )
@@ -11,11 +16,20 @@ versions=( "${versions[@]%/}" )
 
 
 for version in "${versions[@]}"; do
-	fullVersion="$(curl -sSL "http://ftp.osuosl.org/pub/mariadb/repo/$version/debian/dists/wheezy/main/binary-amd64/Packages" | grep -m1 -A10 "^Package: mariadb-server\$" | grep -m1 '^Version: ' | cut -d' ' -f2)"
+	suite="${suites[$version]:-$defaultSuite}"
+	fullVersion="$(curl -sSL "http://ftp.osuosl.org/pub/mariadb/repo/$version/debian/dists/$suite/main/binary-amd64/Packages" |tac|tac| grep -m1 -A10 "^Package: mariadb-server\$" | grep -m1 '^Version: ' | cut -d' ' -f2)"
+	if [ -z "$fullVersion" ]; then
+		echo >&2 "warning: cannot find $version in $suite"
+		continue
+	fi
 	(
 		set -x
 		cp docker-entrypoint.sh Dockerfile.template "$version/"
 		mv "$version/Dockerfile.template" "$version/Dockerfile"
-		sed -i 's/%%MARIADB_MAJOR%%/'$version'/g; s/%%MARIADB_VERSION%%/'$fullVersion'/g' "$version/Dockerfile"
+		sed -i '
+			s/%%SUITE%%/'"$suite"'/g;
+			s/%%MARIADB_MAJOR%%/'"$version"'/g;
+			s/%%MARIADB_VERSION%%/'"$fullVersion"'/g;
+		' "$version/Dockerfile"
 	)
 done


### PR DESCRIPTION
See also http://ftp.osuosl.org/pub/mariadb/repo/10.0/debian/dists/ vs http://ftp.osuosl.org/pub/mariadb/repo/5.5/debian/dists/ (for why 10.0 is moving to jessie but 5.5 has to stick to wheezy).