### PR TITLE
Fix: exec: "/docker-entrypoint.sh": permission denied

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -42,7 +42,7 @@ RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
 VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /
-
+RUN chmod 755 /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 3306


### PR DESCRIPTION
docker run mycontainer:latest
exec: "/docker-entrypoint.sh": permission denied
Error response from daemon: Cannot start container <id>: [8] System error: exec: "/docker-entrypoint.sh": permission denied