### PR TITLE
allow uid and gid to specified on the build command line

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -1,8 +1,11 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
+ARG uid=999
+ARG gid=999
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r mysql --gid=${gid} && useradd -r -g mysql --uid=${uid} mysql
 
 # install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -1,8 +1,10 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
+ARG uid=999
+ARG gid=999
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r mysql --gid=${gid} && useradd -r -g mysql --uid=${uid} mysql
 
 # install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir /docker-entrypoint-initdb.d
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB
 
 ENV MARIADB_MAJOR 10.1
-ENV MARIADB_VERSION 10.1.12+maria-1~jessie
+ENV MARIADB_VERSION 10.1.13+maria-1~jessie
 
 RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,8 +1,10 @@
 # vim:set ft=dockerfile:
 FROM debian:wheezy
+ARG uid=999
+ARG gid=999
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r mysql --gid=${gid} && useradd -r -g mysql --uid=${uid} mysql
 
 # install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The default mysql uid and gid may conflict with other users on the same host.
Currently, Docker does not allow ownership of files on mounted volumes to be changed.
For hosts that employ mounted volumes, the best way to avoid a uid conflict is to inject a unique id for use when the user is initially created. (other options are to map uids on the host using nfs (limiting) or bindfs (slow perfomance).

This pull request simply adds ARGs to each of the 3 Dockerfiles, allowing the desired uid and gid to specified at build time. If the build-arg is not specified, uid and gid default back to the currently generated value, 999.

Usage Example:
> docker build -t and/mariadb-user-fork:10.1.13 --build-arg uid=1001 --build-arg gid=1001 share/and/mariadbfork
