### PR TITLE
Add `apt-get upgrade` to ensure up to date packages

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -41,6 +41,7 @@ RUN { \
 		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections \
 	&& apt-get update \
+	&& apt-get upgrade -y \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -41,6 +41,7 @@ RUN { \
 		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections \
 	&& apt-get update \
+	&& apt-get upgrade -y \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -41,6 +41,7 @@ RUN { \
 		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections \
 	&& apt-get update \
+	&& apt-get upgrade -y \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -41,6 +41,7 @@ RUN { \
 		echo mariadb-server-$MARIADB_MAJOR mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections \
 	&& apt-get update \
+	&& apt-get upgrade -y \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
I'm getting error like this: https://hub.docker.com/r/nazarpc/webserver/builds/bmh7temsuqfvnnenabpqyqx/
Because `mysql-common` was apparently installed from Percona repository and have older version that one from MariaDB repository.