### PR TITLE
Fix double install of mysql-common

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
+# MariaDB Package Signing Key <package-signing-key@mariadb.org>
+# Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
+# Percona MySQL Development Team <mysql-dev@percona.com>
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
 
@@ -17,10 +21,7 @@ RUN echo "deb http://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \
 		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona \
-	&& apt-get update \
-	&& apt-get install -y percona-xtrabackup socat \
-	&& rm -rf /var/lib/apt/lists/*
+	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR 10.0
 ENV MARIADB_VERSION 10.0.24+maria-1~jessie
@@ -43,6 +44,9 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
+# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+		percona-xtrabackup \
+		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql \
 	&& mkdir /var/lib/mysql

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
+# MariaDB Package Signing Key <package-signing-key@mariadb.org>
+# Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
+# Percona MySQL Development Team <mysql-dev@percona.com>
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
 
@@ -17,10 +21,7 @@ RUN echo "deb http://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \
 		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona \
-	&& apt-get update \
-	&& apt-get install -y percona-xtrabackup socat \
-	&& rm -rf /var/lib/apt/lists/*
+	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR 10.1
 ENV MARIADB_VERSION 10.1.13+maria-1~jessie
@@ -43,6 +44,9 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
+# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+		percona-xtrabackup \
+		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql \
 	&& mkdir /var/lib/mysql

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
+# MariaDB Package Signing Key <package-signing-key@mariadb.org>
+# Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
+# Percona MySQL Development Team <mysql-dev@percona.com>
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
 
@@ -17,10 +21,7 @@ RUN echo "deb http://repo.percona.com/apt wheezy main" > /etc/apt/sources.list.d
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \
 		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona \
-	&& apt-get update \
-	&& apt-get install -y percona-xtrabackup socat \
-	&& rm -rf /var/lib/apt/lists/*
+	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR 5.5
 ENV MARIADB_VERSION 5.5.49+maria-1~wheezy
@@ -43,6 +44,9 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
+# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+		percona-xtrabackup \
+		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql \
 	&& mkdir /var/lib/mysql

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,6 +9,10 @@ RUN apt-get update && apt-get install -y pwgen && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+# Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
+# MariaDB Package Signing Key <package-signing-key@mariadb.org>
+# Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
+# Percona MySQL Development Team <mysql-dev@percona.com>
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
 
@@ -17,10 +21,7 @@ RUN echo "deb http://repo.percona.com/apt %%SUITE%% main" > /etc/apt/sources.lis
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \
 		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona \
-	&& apt-get update \
-	&& apt-get install -y percona-xtrabackup socat \
-	&& rm -rf /var/lib/apt/lists/*
+	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR %%MARIADB_MAJOR%%
 ENV MARIADB_VERSION %%MARIADB_VERSION%%
@@ -43,6 +44,9 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
+# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+		percona-xtrabackup \
+		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql \
 	&& mkdir /var/lib/mysql


### PR DESCRIPTION
Fixes #55.  By using only one `apt-get install` this makes sure that we install `mysql-common` once from MariaDB apt repositories and not the wrong version from Debian.

Plus we get to save ~5MB, since now there is only one copy of mysql dependencies.

```console
$ docker images mariadb
mariadb             5.5                 d71a0c37d830        17 seconds ago       272.5 MB
mariadb             10.0                205243a729ab        About a minute ago   338.8 MB
mariadb             10.1                4bfec5fe6b40        2 minutes ago        382.1 MB
mariadb             5.5.48              ad6fae399584        46 hours ago         277.1 MB
mariadb             10.0.24             e52d74783b50        46 hours ago         344.2 MB
mariadb             10.1.13             6cf25c052050        46 hours ago         387.5 MB
```