### PR TITLE
Allow skip database initialization

### DIFF
--- a/10.0/docker-entrypoint.sh
+++ b/10.0/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help --log-bin-index=`mktemp -u` 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_INITDB_SKIP" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '
 			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help --log-bin-index=`mktemp -u` 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_INITDB_SKIP" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '
 			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help --log-bin-index=`mktemp -u` 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_INITDB_SKIP" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '
 			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		chown -R mysql:mysql "$DATADIR"
 
 		echo 'Initializing database'
-		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm
+		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --skip-log-bin
 		echo 'Database initialized'
 
 		"$@" --skip-networking &

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help --log-bin-index=`mktemp -u` 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_INITDB_SKIP" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '
 			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'


### PR DESCRIPTION
This change allows docker-compose to be used to start a galera cluster without initializing nodes separately. e.g. the following compose file will start without error: https://gist.github.com/tanji/919c0dca2e3679acecd7d8cf2a3a886e

In the past there were two workarounds:
- Starting the 1st node separately, then starting node 2 and node 3 when node 1 is fully started. This causes too much time overhead as galera overwrites the initial data through a SST (and can occasionally cause errors).
- Creating a /var/lib/mysql/mysql dir, however this is not really possible inside compose, unless mounting another volume which would be a bit overkill in my opinion.