### PR TITLE
Support multiple comma-separated databases in "MYSQL_DATABASE"

### DIFF
--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -89,7 +89,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		if [ "$MYSQL_DATABASE" ]; then
-			for db2create in $MYSQL_DATABASE; do
+			IFS=, read -a MYSQL_DATABASE <<< "$MYSQL_DATABASE"
+			for db2create in "${MYSQL_DATABASE[@]}"; do
 				echo "CREATE DATABASE IF NOT EXISTS \`$db2create\` ;" | "${mysql[@]}"
 			done
 		fi
@@ -98,7 +99,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then
-				for db2create in $MYSQL_DATABASE; do
+				for db2create in "${MYSQL_DATABASE[@]}"; do
 					echo "GRANT ALL ON \`$db2create\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
 				done
 			fi
@@ -106,7 +107,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
 		fi
 
-		[ "$MYSQL_DATABASE" ] && mysql+=( "${MYSQL_DATABASE%% *}" ) # get first db name
+		[ "$MYSQL_DATABASE" ] && mysql+=( "${MYSQL_DATABASE[0]}" ) # get first db name
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -89,19 +89,24 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
-			mysql+=( "$MYSQL_DATABASE" )
+			for db2create in $MYSQL_DATABASE; do
+				echo "CREATE DATABASE IF NOT EXISTS \`$db2create\` ;" | "${mysql[@]}"
+			done
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
 			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
+				for db2create in $MYSQL_DATABASE; do
+					echo "GRANT ALL ON \`$db2create\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
+				done
 			fi
 
 			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
 		fi
+
+		[ "$MYSQL_DATABASE" ] && mysql+=( "${MYSQL_DATABASE%% *}" ) # get first db name
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -107,7 +107,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
 		fi
 
-		[ "$MYSQL_DATABASE" ] && mysql+=( "${MYSQL_DATABASE[0]}" ) # get first db name
+		# get first db name
+		[ "$MYSQL_DATABASE" ] && mysql+=( "${MYSQL_DATABASE[0]}" )
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do


### PR DESCRIPTION
For now, SQL scripts inside "/docker-entrypoint-initdb.d" will be executed on the first database only.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-library/mariadb/63)

<!-- Reviewable:end -->
