### PR TITLE
Revert "Update to 10.1.15"

### DIFF
--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "deb http://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d
 	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR 10.1
-ENV MARIADB_VERSION 10.1.15+maria-1~jessie
+ENV MARIADB_VERSION 10.1.14+maria-1~jessie
 
 RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \


### PR DESCRIPTION
This reverts commit 14fa9fab60856471be80afdbb4044f31d78e9a08.

I asked on #mariadb regards 10.1.15 as I couldn't find it on mariadb website.

Sergei Golubchik responded "it was pulled off because of regressions, there will be 10.1.16 in two weeks"..