### PR TITLE
expose ports for Galera replication traffic

### DIFF
--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -86,5 +86,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 3306
+EXPOSE 3306 4567 4568 4444
+EXPOSE 4567/udp
 CMD ["mysqld"]


### PR DESCRIPTION
These additional ports are used for Galera cluster replication traffic and should be exposed to facilitate running a cluster in a Docker overlay network.
