### PR TITLE
Entrypoint script ignoring non files

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,7 +106,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			if [ ! -f "$f" ]; then
-		        	echo "$0: ignoring is not a file $f"; echo
+		        	echo "$0: ignoring $f (not a file)"; echo
 		        	continue
 		    	fi
 			case "$f" in

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,9 +106,9 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			if [ ! -f "$f" ]; then
-		        echo "$0: ignoring is not a file $f"; echo
-		        continue
-		    fi
+		        	echo "$0: ignoring is not a file $f"; echo
+		        	continue
+		    	fi
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
 				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -105,6 +105,10 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
+			if [ ! -f "$f" ]; then
+		        echo "$0: ignoring is not a file $f"; echo
+		        continue
+		    fi
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
 				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;


### PR DESCRIPTION
If a SQL file does not exist in the docker machine to be mounted, the mount point is created as an empty folder. This pull request prevents the entrypoint script stop because of this.
