### PR TITLE
Failed to run the images due to file permission problem of docker-entrypoint.sh file

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -91,6 +91,7 @@ VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -91,6 +91,7 @@ VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -91,6 +91,7 @@ VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306


### PR DESCRIPTION
When I was trying to integrate this docker image to my environment and run it, I got this error:

docker: Error response from daemon: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"docker-entrypoint.sh\\\": executable file not found in $PATH\"\n".

In the end found it's actually because the docker-entrypoint.sh wasn't executable. 