### PR TITLE
Adding env_var APP_HOST cause of security

### DIFF
--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -119,11 +119,21 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			SET @@SESSION.SQL_LOG_BIN=0;
 
 			DELETE FROM mysql.user ;
-			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+			CREATE USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 			DROP DATABASE IF EXISTS test ;
 			FLUSH PRIVILEGES ;
 		EOSQL
+		
+		file_env 'APP_HOST'
+      		if [ ! -z "$APP_HOST" ]; then
+                        APPHOST='%'
+                elif [ "$APP_HOST" == 'localhost' || "$APP_HOST" == '127.0.0.1' ]; then
+                        APPHOST='localhost'
+                else
+                        APPHOST=$APP_HOST
+                fi
+
 
 		if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
 			mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
@@ -138,10 +148,10 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		file_env 'MYSQL_USER'
 		file_env 'MYSQL_PASSWORD'
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | "${mysql[@]}"
+			echo "CREATE USER '$MYSQL_USER'@'$APP_HOST' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
+				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'$APP_HOST' ;" | "${mysql[@]}"
 			fi
 
 			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -119,8 +119,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			SET @@SESSION.SQL_LOG_BIN=0;
 
 			DELETE FROM mysql.user ;
-			CREATE USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-			GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
+			CREATE USER 'root'@'127.0.0.1' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION ;
 			DROP DATABASE IF EXISTS test ;
 			FLUSH PRIVILEGES ;
 		EOSQL
@@ -129,7 +129,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
       		if [ ! -z "$APP_HOST" ]; then
                         APPHOST='%'
                 elif [ "$APP_HOST" == 'localhost' || "$APP_HOST" == '127.0.0.1' ]; then
-                        APPHOST='localhost'
+                        APPHOST='127.0.0.1'
                 else
                         APPHOST=$APP_HOST
                 fi


### PR DESCRIPTION
I want to add APP_HOST, because you used % for the user access. That isn't secure. root should have access on localhost and the created MYSQL_USER should use the IP address of the application server. I added APP_HOST for that. I want to improve the security of the mariadb docker image with that.

Thanks!