### PR TITLE
Use "/etc/apt/trusted.gpg.d" instead of "apt-key adv"

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -27,19 +27,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pwgen \
 	&& rm -rf /var/lib/apt/lists/*
 
+ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
+	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 # pub   1024D/CD2EFD2A 2009-12-15
 #       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
 # uid                  Percona MySQL Development Team <mysql-dev@percona.com>
 # sub   2048g/2D607DAF 2009-12-15
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
+	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
 # pub   4096R/8507EFA5 2016-06-30
 #       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
 # uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
 # sub   4096R/4CAC6D72 2016-06-30
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 4D1BB29D63D98E422B2113B19334A25F8507EFA5
+	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
 	&& { \

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -27,19 +27,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pwgen \
 	&& rm -rf /var/lib/apt/lists/*
 
+ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
+	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 # pub   1024D/CD2EFD2A 2009-12-15
 #       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
 # uid                  Percona MySQL Development Team <mysql-dev@percona.com>
 # sub   2048g/2D607DAF 2009-12-15
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
+	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
 # pub   4096R/8507EFA5 2016-06-30
 #       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
 # uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
 # sub   4096R/4CAC6D72 2016-06-30
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 4D1BB29D63D98E422B2113B19334A25F8507EFA5
+	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
 	&& { \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -27,19 +27,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pwgen \
 	&& rm -rf /var/lib/apt/lists/*
 
+ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
+	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 # pub   1024D/CD2EFD2A 2009-12-15
 #       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
 # uid                  Percona MySQL Development Team <mysql-dev@percona.com>
 # sub   2048g/2D607DAF 2009-12-15
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
+	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
 # pub   4096R/8507EFA5 2016-06-30
 #       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
 # uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
 # sub   4096R/4CAC6D72 2016-06-30
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 4D1BB29D63D98E422B2113B19334A25F8507EFA5
+	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 RUN echo "deb https://repo.percona.com/apt wheezy main" > /etc/apt/sources.list.d/percona.list \
 	&& { \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,19 +27,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pwgen \
 	&& rm -rf /var/lib/apt/lists/*
 
+ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
+	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
 # pub   1024D/CD2EFD2A 2009-12-15
 #       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
 # uid                  Percona MySQL Development Team <mysql-dev@percona.com>
 # sub   2048g/2D607DAF 2009-12-15
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
+	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
 # pub   4096R/8507EFA5 2016-06-30
 #       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
 # uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
 # sub   4096R/4CAC6D72 2016-06-30
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 4D1BB29D63D98E422B2113B19334A25F8507EFA5
+	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 RUN echo "deb https://repo.percona.com/apt %%SUITE%% main" > /etc/apt/sources.list.d/percona.list \
 	&& { \


### PR DESCRIPTION
> Note: Instead of using this command a keyring should be placed
> directly in the /etc/apt/trusted.gpg.d/ directory with a
> descriptive name and either "gpg" or "asc" as file extension.

https://manpages.debian.org/cgi-bin/man.cgi?query=apt-key&manpath=Debian+testing+stretch

See also https://github.com/docker-library/cassandra/pull/91.