### PR TITLE
Use xtrabackup 2.4 for mariadb 10.2 compatibility

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -78,8 +78,8 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		mariadb-server=$MARIADB_VERSION \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
+# percona-xtrabackup-24 is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+		percona-xtrabackup-24 \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)


### PR DESCRIPTION
According to https://mariadb.com/kb/en/mariadb/percona-xtrabackup/, if we want to use XtraBackup for MariaDB data, we should use Percona XtraBackup 2.4 for MariaDB Server versions beginning with 10.2.
XtraBackup 2.3 and 2.4 are both available from the MariaDB Package Repository, but XtraBackup 2.3 packages are called percona-xtrabackup while XtraBackup 2.4 packages are called percona-xtrabackup-24.
This is why, in order to correctly start a MariaDB cluster, we will need to install percona-xtrabackup-24.