### PR TITLE
Update templates for TokuDB plugin usage

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -81,6 +81,7 @@ RUN { \
 		"mariadb-server=$MARIADB_VERSION" \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		percona-xtrabackup \
+		 \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -81,6 +81,7 @@ RUN { \
 		"mariadb-server=$MARIADB_VERSION" \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		percona-xtrabackup \
+		 \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -81,6 +81,7 @@ RUN { \
 		"mariadb-server=$MARIADB_VERSION" \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		percona-xtrabackup-24 \
+		mariadb-plugin-tokudb \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -81,6 +81,7 @@ RUN { \
 		"mariadb-server=$MARIADB_VERSION" \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		percona-xtrabackup-24 \
+		mariadb-plugin-tokudb \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -81,6 +81,7 @@ RUN { \
 		"mariadb-server=$MARIADB_VERSION" \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		percona-xtrabackup \
+		 \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -81,6 +81,7 @@ RUN { \
 		"mariadb-server=$MARIADB_VERSION" \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		%%XTRABACKUP%% \
+		%%TOKUDBPLUGIN%% \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,12 @@ declare -A xtrabackups=(
 	[10.1]='percona-xtrabackup'
 )
 
+defaultTokudbPlugin=''
+declare -A tokudbPlugins=(
+	[10.2]='mariadb-plugin-tokudb'
+	[10.3]='mariadb-plugin-tokudb'
+)
+
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( "$@" )
@@ -40,6 +46,7 @@ for version in "${versions[@]}"; do
 			-e 's!%%MARIADB_MAJOR%%!'"$version"'!g' \
 			-e 's!%%SUITE%%!'"$suite"'!g' \
 			-e 's!%%XTRABACKUP%%!'"${xtrabackups[$version]:-$defaultXtrabackup}"'!g' \
+			-e 's!%%TOKUDBPLUGIN%%!'"${tokudbPlugins[$version]:-$defaultTokudbPlugin}"'!g' \
 			Dockerfile.template \
 			> "$version/Dockerfile"
 	)


### PR DESCRIPTION
TokuDB engine has been split into a separate package, mariadb-plugin-tokudb in MariaDB version 10.2.
[Upgrading from MariaDB 10.1 to MariaDB 10.2](https://mariadb.com/kb/en/the-mariadb-library/upgrading-from-mariadb-101-to-mariadb-102/#tokudb)
This pull request installs mariadb-plugin-tokudb for MariaDB version 10.2 and 10.3. Prior version was untouched.