### PR TITLE
Add env variable to skip database initialization

### DIFF
--- a/10.0/docker-entrypoint.sh
+++ b/10.0/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_SKIP_INIT" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_SKIP_INIT" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_SKIP_INIT" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_SKIP_INIT" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_SKIP_INIT" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR/mysql" ] && [ -z "$MYSQL_SKIP_INIT" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '


### PR DESCRIPTION
This add a new env variable (MYSQL_SKIP_INIT=1) which skip the
database initialization.

This is useful, when the server act as a Galera node, initializing
the datadir make no sense in that case, as a copy of the datadir
is transfered from another node in the cluster.

See: http://galeracluster.com/documentation-webpages/statetransfer.html
----
**Note:** I haven't tested this. For years I have just executed `mkdir -p /var/lib/mysql/mysql` before starting the container, but this is more correct.