### PR TITLE
percona repository is amd64 and i386 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: bash
 services: docker
 
+os:
+  - linux
+  - linux-ppc64le
+
 env:
   - VERSION=5.5
   - VERSION=10.3
   - VERSION=10.2
   - VERSION=10.1
   - VERSION=10.0
+
+matrix:
+  exclude:
+   - os: linux-ppc64le
+     env: VERSION=5.5
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -89,12 +89,14 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessi
 RUN { \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password password 'unused'; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
+	} | debconf-set-selections; \
+	arch="$(dpkg --print-architecture)"; \
+# percona-xtrabackup(amd64/i386 only) is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+	if [ "$arch" = "amd64" ] || [ "$arch" = "i386" ]; then XTRABACKUP=percona-xtrabackup ; else XTRABACKUP= ; fi ; \
+	apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
+		"${XTRABACKUP}" \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -65,7 +65,7 @@ RUN set -ex; \
 	apt-key list
 
 # add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
+RUN echo "deb [arch=amd64,i386] https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -89,12 +89,14 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessi
 RUN { \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password password 'unused'; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
+	} | debconf-set-selections; \
+	arch="$(dpkg --print-architecture)"; \
+# percona-xtrabackup(amd64/i386 only) is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+	if [ "$arch" = "amd64" ] || [ "$arch" = "i386" ]; then XTRABACKUP=percona-xtrabackup ; else XTRABACKUP= ; fi ; \
+	apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
+		"${XTRABACKUP}" \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -65,7 +65,7 @@ RUN set -ex; \
 	apt-key list
 
 # add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
+RUN echo "deb [arch=amd64,i386] https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -89,12 +89,14 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessi
 RUN { \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password password 'unused'; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
+	} | debconf-set-selections; \
+	arch="$(dpkg --print-architecture)"; \
+# percona-xtrabackup(amd64/i386 only) is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+	if [ "$arch" = "amd64" ] || [ "$arch" = "i386" ]; then XTRABACKUP=percona-xtrabackup-24 ; else XTRABACKUP= ; fi ; \
+	apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup-24 \
+		"${XTRABACKUP}" \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -65,7 +65,7 @@ RUN set -ex; \
 	apt-key list
 
 # add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
+RUN echo "deb [arch=amd64,i386] https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -89,12 +89,14 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessi
 RUN { \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password password 'unused'; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
+	} | debconf-set-selections; \
+	arch="$(dpkg --print-architecture)"; \
+# percona-xtrabackup(amd64/i386 only) is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+	if [ "$arch" = "amd64" ] || [ "$arch" = "i386" ]; then XTRABACKUP=percona-xtrabackup-24 ; else XTRABACKUP= ; fi ; \
+	apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup-24 \
+		"${XTRABACKUP}" \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -65,7 +65,7 @@ RUN set -ex; \
 	apt-key list
 
 # add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
+RUN echo "deb [arch=amd64,i386] https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -89,12 +89,14 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian wheez
 RUN { \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password password 'unused'; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
+	} | debconf-set-selections; \
+	arch="$(dpkg --print-architecture)"; \
+# percona-xtrabackup(amd64/i386 only) is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+	if [ "$arch" = "amd64" ] || [ "$arch" = "i386" ]; then XTRABACKUP=percona-xtrabackup ; else XTRABACKUP= ; fi ; \
+	apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
+		"${XTRABACKUP}" \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -65,7 +65,7 @@ RUN set -ex; \
 	apt-key list
 
 # add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt wheezy main" > /etc/apt/sources.list.d/percona.list \
+RUN echo "deb [arch=amd64,i386] https://repo.percona.com/apt wheezy main" > /etc/apt/sources.list.d/percona.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -65,7 +65,7 @@ RUN set -ex; \
 	apt-key list
 
 # add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt %%SUITE%% main" > /etc/apt/sources.list.d/percona.list \
+RUN echo "deb [arch=amd64,i386] https://repo.percona.com/apt %%SUITE%% main" > /etc/apt/sources.list.d/percona.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -89,12 +89,14 @@ RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian %%SUI
 RUN { \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password password 'unused'; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
+	} | debconf-set-selections; \
+	arch="$(dpkg --print-architecture)"; \
+# percona-xtrabackup(amd64/i386 only) is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
+	if [ "$arch" = "amd64" ] || [ "$arch" = "i386" ]; then XTRABACKUP=%%XTRABACKUP%% ; else XTRABACKUP= ; fi ; \
+	apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		%%XTRABACKUP%% \
+		"${XTRABACKUP}" \
 		socat \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)


### PR DESCRIPTION

At least for the xtrabackup that is used in the Docker files here.