### PR TITLE
Switch 10.1, 10.2 and 10.3 to Stretch and switch to mariabackup

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -4,6 +4,15 @@ FROM debian:jessie
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# install "pwgen" for randomizing passwords
+# install "gnupg" for gpg
+# install "dirmngr" for gpg key importing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		pwgen \
+		gnupg \
+		dirmngr \
+	&& rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
 RUN set -ex; \
@@ -34,27 +43,13 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
 	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+# Key fingerprint = 177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# MariaDB Signing Key <signing-key@mariadb.org>
+	177F4010FE56CA3336300305F1656F24C74CD1D8
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
@@ -63,14 +58,6 @@ RUN set -ex; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
-
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=Percona Development Team'; \
-		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR 10.0
 ENV MARIADB_VERSION 10.0.34+maria-1~jessie
@@ -93,9 +80,15 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
-		socat \
+		 \
+	# Ensure xtrabkacup SST continue to work, so we don't break existing setups.
+	&& (test ! -f /usr/bin/mariabackup && true \
+		|| (ln -s mariabackup /usr/bin/xtrabackup \
+		&& echo -e '#!/bin/bash\nmariabackup --innobackupex "${@}"' > /usr/bin/innobackupex \
+		&& chmod +x /usr/bin/innobackupex \
+		&& ln -s mbstream /usr/bin/xbstream \
+		&& sed 's/XB_REQUIRED_VERSION=.*/XB_REQUIRED_VERSION=""/' -i /usr/bin/wsrep_sst_xtrabackup-v2) \
+	) \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -1,8 +1,17 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:stretch
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+# install "pwgen" for randomizing passwords
+# install "gnupg" for gpg
+# install "dirmngr" for gpg key importing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		pwgen \
+		gnupg \
+		dirmngr \
+	&& rm -rf /var/lib/apt/lists/*
 
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -34,27 +43,13 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
 	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+# Key fingerprint = 177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# MariaDB Signing Key <signing-key@mariadb.org>
+	177F4010FE56CA3336300305F1656F24C74CD1D8
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
@@ -64,18 +59,10 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=Percona Development Team'; \
-		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona
-
 ENV MARIADB_MAJOR 10.1
-ENV MARIADB_VERSION 10.1.32+maria-1~jessie
+ENV MARIADB_VERSION 10.1.32+maria-1~stretch
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian stretch main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=MariaDB'; \
@@ -93,9 +80,15 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
-		socat \
+		libaio1 libjemalloc1 libssl1.0.2 procps socat mariadb-backup-10.1=10.1.32+maria-1~stretch \
+	# Ensure xtrabkacup SST continue to work, so we don't break existing setups.
+	&& (test ! -f /usr/bin/mariabackup && true \
+		|| (ln -s mariabackup /usr/bin/xtrabackup \
+		&& echo -e '#!/bin/bash\nmariabackup --innobackupex "${@}"' > /usr/bin/innobackupex \
+		&& chmod +x /usr/bin/innobackupex \
+		&& ln -s mbstream /usr/bin/xbstream \
+		&& sed 's/XB_REQUIRED_VERSION=.*/XB_REQUIRED_VERSION=""/' -i /usr/bin/wsrep_sst_xtrabackup-v2) \
+	) \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -1,8 +1,17 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:stretch
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+# install "pwgen" for randomizing passwords
+# install "gnupg" for gpg
+# install "dirmngr" for gpg key importing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		pwgen \
+		gnupg \
+		dirmngr \
+	&& rm -rf /var/lib/apt/lists/*
 
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -34,27 +43,13 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
 	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+# Key fingerprint = 177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# MariaDB Signing Key <signing-key@mariadb.org>
+	177F4010FE56CA3336300305F1656F24C74CD1D8
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
@@ -64,18 +59,10 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=Percona Development Team'; \
-		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona
-
 ENV MARIADB_MAJOR 10.2
-ENV MARIADB_VERSION 10.2.14+maria~jessie
+ENV MARIADB_VERSION 10.2.14+maria~stretch
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian stretch main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=MariaDB'; \
@@ -93,9 +80,15 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup-24 \
-		socat \
+		libaio1 libjemalloc1 libssl1.0.2 procps socat mariadb-backup-10.2=10.2.14+maria~stretch \
+	# Ensure xtrabkacup SST continue to work, so we don't break existing setups.
+	&& (test ! -f /usr/bin/mariabackup && true \
+		|| (ln -s mariabackup /usr/bin/xtrabackup \
+		&& echo -e '#!/bin/bash\nmariabackup --innobackupex "${@}"' > /usr/bin/innobackupex \
+		&& chmod +x /usr/bin/innobackupex \
+		&& ln -s mbstream /usr/bin/xbstream \
+		&& sed 's/XB_REQUIRED_VERSION=.*/XB_REQUIRED_VERSION=""/' -i /usr/bin/wsrep_sst_xtrabackup-v2) \
+	) \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -1,8 +1,17 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:stretch
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+# install "pwgen" for randomizing passwords
+# install "gnupg" for gpg
+# install "dirmngr" for gpg key importing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		pwgen \
+		gnupg \
+		dirmngr \
+	&& rm -rf /var/lib/apt/lists/*
 
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -34,27 +43,13 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
 	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+# Key fingerprint = 177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# MariaDB Signing Key <signing-key@mariadb.org>
+	177F4010FE56CA3336300305F1656F24C74CD1D8
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
@@ -64,18 +59,10 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=Percona Development Team'; \
-		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona
-
 ENV MARIADB_MAJOR 10.3
-ENV MARIADB_VERSION 10.3.5+maria~jessie
+ENV MARIADB_VERSION 10.3.5+maria~stretch
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
+RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian stretch main" > /etc/apt/sources.list.d/mariadb.list \
 	&& { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=MariaDB'; \
@@ -93,9 +80,15 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup-24 \
-		socat \
+		libaio1 libjemalloc1 libssl1.0.2 procps socat mariadb-backup-10.3=10.3.5+maria~stretch \
+	# Ensure xtrabkacup SST continue to work, so we don't break existing setups.
+	&& (test ! -f /usr/bin/mariabackup && true \
+		|| (ln -s mariabackup /usr/bin/xtrabackup \
+		&& echo -e '#!/bin/bash\nmariabackup --innobackupex "${@}"' > /usr/bin/innobackupex \
+		&& chmod +x /usr/bin/innobackupex \
+		&& ln -s mbstream /usr/bin/xbstream \
+		&& sed 's/XB_REQUIRED_VERSION=.*/XB_REQUIRED_VERSION=""/' -i /usr/bin/wsrep_sst_xtrabackup-v2) \
+	) \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -4,6 +4,15 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# install "pwgen" for randomizing passwords
+# install "gnupg" for gpg
+# install "dirmngr" for gpg key importing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		pwgen \
+		gnupg \
+		dirmngr \
+	&& rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
 RUN set -ex; \
@@ -34,27 +43,13 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
 	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+# Key fingerprint = 177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# MariaDB Signing Key <signing-key@mariadb.org>
+	177F4010FE56CA3336300305F1656F24C74CD1D8
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
@@ -63,14 +58,6 @@ RUN set -ex; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
-
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt wheezy main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=Percona Development Team'; \
-		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR 5.5
 ENV MARIADB_VERSION 5.5.59+maria-1~wheezy
@@ -93,9 +80,15 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		percona-xtrabackup \
-		socat \
+		 \
+	# Ensure xtrabkacup SST continue to work, so we don't break existing setups.
+	&& (test ! -f /usr/bin/mariabackup && true \
+		|| (ln -s mariabackup /usr/bin/xtrabackup \
+		&& echo -e '#!/bin/bash\nmariabackup --innobackupex "${@}"' > /usr/bin/innobackupex \
+		&& chmod +x /usr/bin/innobackupex \
+		&& ln -s mbstream /usr/bin/xbstream \
+		&& sed 's/XB_REQUIRED_VERSION=.*/XB_REQUIRED_VERSION=""/' -i /usr/bin/wsrep_sst_xtrabackup-v2) \
+	) \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,15 @@ FROM debian:%%SUITE%%
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# install "pwgen" for randomizing passwords
+# install "gnupg" for gpg
+# install "dirmngr" for gpg key importing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		pwgen \
+		gnupg \
+		dirmngr \
+	&& rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
 RUN set -ex; \
@@ -34,27 +43,13 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEYS \
 # Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
 # MariaDB Package Signing Key <package-signing-key@mariadb.org>
 	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+# Key fingerprint = 177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# MariaDB Signing Key <signing-key@mariadb.org>
+	177F4010FE56CA3336300305F1656F24C74CD1D8
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
@@ -63,14 +58,6 @@ RUN set -ex; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
-
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt %%SUITE%% main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=Percona Development Team'; \
-		echo 'Pin-Priority: 998'; \
-	} > /etc/apt/preferences.d/percona
 
 ENV MARIADB_MAJOR %%MARIADB_MAJOR%%
 ENV MARIADB_VERSION %%MARIADB_VERSION%%
@@ -93,9 +80,15 @@ RUN { \
 	&& apt-get update \
 	&& apt-get install -y \
 		"mariadb-server=$MARIADB_VERSION" \
-# percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-		%%XTRABACKUP%% \
-		socat \
+		%%MARIABACKUP%% \
+	# Ensure xtrabkacup SST continue to work, so we don't break existing setups.
+	&& (test ! -f /usr/bin/mariabackup && true \
+		|| (ln -s mariabackup /usr/bin/xtrabackup \
+		&& echo -e '#!/bin/bash\nmariabackup --innobackupex "${@}"' > /usr/bin/innobackupex \
+		&& chmod +x /usr/bin/innobackupex \
+		&& ln -s mbstream /usr/bin/xbstream \
+		&& sed 's/XB_REQUIRED_VERSION=.*/XB_REQUIRED_VERSION=""/' -i /usr/bin/wsrep_sst_xtrabackup-v2) \
+	) \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \

--- a/update.sh
+++ b/update.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -eo pipefail
 
-defaultSuite='jessie'
+defaultSuite='stretch'
 declare -A suites=(
 	[5.5]='wheezy'
+	[10.0]='jessie'
 )
-defaultXtrabackup='percona-xtrabackup-24'
-declare -A xtrabackups=(
-	[5.5]='percona-xtrabackup'
-	[10.0]='percona-xtrabackup'
-	[10.1]='percona-xtrabackup'
+# https://jira.mariadb.org/browse/MDEV-15869
+defaultMariabackup='libaio1 libjemalloc1 libssl1.0.2 procps socat mariadb-backup-'
+declare -A mariabackups=(
+	[5.5]=''
+	[10.0]=''
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
@@ -39,7 +40,7 @@ for version in "${versions[@]}"; do
 			-e 's!%%MARIADB_VERSION%%!'"$fullVersion"'!g' \
 			-e 's!%%MARIADB_MAJOR%%!'"$version"'!g' \
 			-e 's!%%SUITE%%!'"$suite"'!g' \
-			-e 's!%%XTRABACKUP%%!'"${xtrabackups[$version]:-$defaultXtrabackup}"'!g' \
+			-e 's!%%MARIABACKUP%%!'"${mariabackups[$version]-$defaultMariabackup$version=$fullVersion}"'!g' \
 			Dockerfile.template \
 			> "$version/Dockerfile"
 	)


### PR DESCRIPTION
* Switch 10.1, 10.2 and 10.3 to Stretch
* Add gnupg and dirmngr explicitly, as they are no longer installed
  as default.
* Add new MariaDB Signing Key [1]
* Drop xtrabackup from all image
* Install mariabackup in 10.1, 10.2 and 10.3
* Add procps explicitly, as it is needed by SST.
* Add mariabackup dependencies explicitly due to upstream bug:
  https://jira.mariadb.org/browse/MDEV-15869
* Ensure xtrabackup SST continue to work, so we don't break existing
  setups.
  Symlinks: xtrabackup -> mariabackup, xbstream -> mbstream
  Remove xtrabackup-v2 innobackupex version check
  innobackupex wrapper which start mariabackup with --innobackupex
  Tested on a 10.1 Galera setup with wsrep_sst_method="xtrabackup-v2"

[1] https://mariadb.com/kb/en/library/installing-mariadb-deb-files/#new-key

---

Should fix everything mentioned in https://github.com/docker-library/mariadb/pull/111

cc @tianon 