### PR TITLE
Add suite aliases like jessie and wheezy

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -63,6 +63,14 @@ for version in "${versions[@]}"; do
 	fi
 	versionAliases+=( ${aliases[$version]:-} )
 
+	from="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "FROM" { print $2; exit }')"
+	distro="${from%%:*}" # "debian", "ubuntu"
+	suite="${from#$distro:}" # "jessie-slim", "xenial"
+	suite="${suite%-slim}" # "jessie", "xenial"
+
+	variantAliases=( "${versionAliases[@]/%/-$suite}" )
+	versionAliases=( "${variantAliases[@]//latest-/}" "${versionAliases[@]}" )
+
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${versionAliases[@]}")


### PR DESCRIPTION
This is so we can move toward changing the base to Ubuntu to get more architectures and a supported release for 5.5 since wheezy LTS is end of life.