### PR TITLE
Base MariaDB 10.3 image of Debian Stretch (slim)

### DIFF
--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -1,88 +1,55 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:stretch-slim
+ENV MARIADB_MAJOR 10.3
+ENV MARIADB_VERSION 1:10.3.8+maria~stretch
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# add gosu for easy step-down from root
-ENV GOSU_VERSION 1.10
+# Add a few packages we'll be needing later on.
+# wget and apt-transport-https for installing Percona repo and tools
+# gpg so we can add the keys for the MariaDB repo using apt-key
 RUN set -ex; \
 	\
 	fetchDeps=' \
+    apt-transport-https \
+    apt-utils \
 		ca-certificates \
-		wget \
+    dirmngr \
+    gosu \
+    gpg \
+    software-properties-common \
+    wget \
 	'; \
 	apt-get update; \
-	apt-get install -y --no-install-recommends $fetchDeps; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
-	chmod +x /usr/local/bin/gosu; \
-# verify that the binary works
-	gosu nobody true; \
-	\
-	apt-get purge -y --auto-remove $fetchDeps
+	apt-get install -y --no-install-recommends $fetchDeps
+  
+# Add the MariaDB repository, per https://downloads.mariadb.org/mariadb/repositories/
+# Note: We can't do this before the packages above is installed, because we need gpg.
+RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8
+RUN add-apt-repository 'deb [arch=amd64] http://mirrors.dotsrc.org/mariadb/repo/10.3/debian stretch main'
 
-RUN mkdir /docker-entrypoint-initdb.d
+RUN { \
+		echo 'Package: *'; \
+		echo 'Pin: release o=MariaDB'; \
+		echo 'Pin-Priority: 999'; \
+} > /etc/apt/preferences.d/mariadb
 
-# install "pwgen" for randomizing passwords
-# install "apt-transport-https" for Percona's repo (switched to https-only)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
+# Install the Percona repository
+# https://www.percona.com/doc/percona-xtrabackup/LATEST/installation/apt_repo.html
+RUN wget https://repo.percona.com/apt/percona-release_0.1-6.$(lsb_release -sc)_all.deb; \
+  dpkg -i percona-release_0.1-6.$(lsb_release -sc)_all.deb; \
+  rm percona-release_0.1-6.$(lsb_release -sc)_all.deb
 
-ENV GPG_KEYS \
-# Key fingerprint = 1993 69E5 404B D5FC 7D2F  E43B CBCB 082A 1BB9 43DB
-# MariaDB Package Signing Key <package-signing-key@mariadb.org>
-	199369E5404BD5FC7D2FE43BCBCB082A1BB943DB \
-# pub   1024D/CD2EFD2A 2009-12-15
-#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
-# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
-# sub   2048g/2D607DAF 2009-12-15
-	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-# pub   4096R/8507EFA5 2016-06-30
-#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
-# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
-# sub   4096R/4CAC6D72 2016-06-30
-	4D1BB29D63D98E422B2113B19334A25F8507EFA5
-RUN set -ex; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done; \
-	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mariadb.gpg; \
-	rm -r "$GNUPGHOME"; \
-	apt-key list
-
-# add Percona's repo for xtrabackup (which is useful for Galera)
-RUN echo "deb https://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list \
-	&& { \
+# Pin Percona repository
+RUN { \
 		echo 'Package: *'; \
 		echo 'Pin: release o=Percona Development Team'; \
 		echo 'Pin-Priority: 998'; \
 	} > /etc/apt/preferences.d/percona
 
-ENV MARIADB_MAJOR 10.3
-ENV MARIADB_VERSION 1:10.3.8+maria~jessie
 
-RUN echo "deb http://ftp.osuosl.org/pub/mariadb/repo/$MARIADB_MAJOR/debian jessie main" > /etc/apt/sources.list.d/mariadb.list \
-	&& { \
-		echo 'Package: *'; \
-		echo 'Pin: release o=MariaDB'; \
-		echo 'Pin-Priority: 999'; \
-	} > /etc/apt/preferences.d/mariadb
-# add repository pinning to make sure dependencies from this MariaDB repo are preferred over Debian dependencies
-#  libmariadbclient18 : Depends: libmysqlclient18 (= 5.5.42+maria-1~wheezy) but 5.5.43-0+deb7u1 is to be installed
+RUN mkdir /docker-entrypoint-initdb.d
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
@@ -96,7 +63,6 @@ RUN { \
 # percona-xtrabackup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 		percona-xtrabackup-24 \
 		socat \
-	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
 	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \
 # purge and re-create /var/lib/mysql with appropriate ownership
@@ -110,6 +76,10 @@ RUN { \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
 # don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+
+# Cleanup
+RUN rm -rf /var/lib/apt/lists/*; \
+  apt-get purge -y --auto-remove $fetchDeps
 
 VOLUME /var/lib/mysql
 


### PR DESCRIPTION
Switch the 10.3 image to be based of Debian Stretch (slim), rather the Jessie, as Jessie is already in LTS support mode.

Clean up things a bit, there's a lot of repository management that has become simple between Jessie and Stretch.