### PR TITLE
mariadb-5.5 doesn't support ppc64le

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -88,7 +88,7 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-# bashbrew-architectures: amd64 i386 ppc64le
+# bashbrew-architectures: amd64 i386
 ENV MARIADB_MAJOR 5.5
 ENV MARIADB_VERSION 5.5.60+maria-1~trusty
 


### PR DESCRIPTION
closes #154 

thanks for resolving the migration of so many converging issues and adding support to 10.0+ versions