### PR TITLE
Fix mysql_install_db to create initial mysql root without a password

### DIFF
--- a/10.0/docker-entrypoint.sh
+++ b/10.0/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,8 +90,15 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mkdir -p "$DATADIR"
 
 		echo 'Initializing database'
+		installArgs=( --datadir="$DATADIR" --rpm )
+		if { mysql_install_db --help || :; } | grep -q -- '--auth-root-authentication-method'; then
+			# beginning in 10.4.3, install_db uses "socket" which only allows system user root to connect, switch back to "normal" to allow mysql root without a password
+			# see https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3
+			# (this flag doesn't exist in 10.0 and below)
+			installArgs+=( --auth-root-authentication-method=normal )
+		fi
 		# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-		mysql_install_db --datadir="$DATADIR" --rpm "${@:2}"
+		mysql_install_db "${installArgs[@]}" "${@:2}"
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"


### PR DESCRIPTION
Rather than the new mode of only via system `root` user.

See also https://github.com/MariaDB/server/commit/b9f3f06857ac6f9105dc65caae19782f09b47fb3#diff-f38e7b3e336a72eae83c8c7f7a177f7bL48

Not 100% sold on this implementation. Better ideas?