### PR TITLE
Add "rc", "alpha", "beta", "gamma" aliases automatically (but only to the highest version of each)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -76,6 +76,13 @@ for version in "${versions[@]}"; do
 				versionAliases+=( "$tryAlias" )
 			fi
 		done
+	else
+		for tryAlias in "${releaseStatus,,}"; do
+			if [ -z "${latest[$tryAlias]:-}" ]; then
+				latest[$tryAlias]="$version"
+				versionAliases+=( "$tryAlias" )
+			fi
+		done
 	fi
 
 	from="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "FROM" { print $2; exit }')"


### PR DESCRIPTION
This is a follow-up to #229; the concrete effect of this today will be a new `mariadb:rc` tag pointing to `mariadb:10.4.3`.