### PR TITLE
Remove obsolete ca-certificates

### DIFF
--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -48,14 +48,15 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "apt-transport-https" for Percona's repo (switched to https-only)
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEYS \
 # pub   rsa4096 2016-03-30 [SC]

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -48,14 +48,15 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "apt-transport-https" for Percona's repo (switched to https-only)
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEYS \
 # pub   rsa4096 2016-03-30 [SC]

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -48,14 +48,15 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "apt-transport-https" for Percona's repo (switched to https-only)
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEYS \
 # pub   rsa4096 2016-03-30 [SC]

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -48,14 +48,15 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "apt-transport-https" for Percona's repo (switched to https-only)
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEYS \
 # pub   rsa4096 2016-03-30 [SC]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -48,14 +48,15 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "apt-transport-https" for Percona's repo (switched to https-only)
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEYS \
 # pub   rsa4096 2016-03-30 [SC]

--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,7 @@ getRemoteVersion() {
 	local dpkgArch="$1" shift # arm64
 
 	echo "$(
-		curl -fsSL "http://ftp.osuosl.org/pub/mariadb/repo/$version/ubuntu/dists/$suite/main/binary-$dpkgArch/Packages" 2>/dev/null  \
+		curl -fsSL "https://ftp.osuosl.org/pub/mariadb/repo/$version/ubuntu/dists/$suite/main/binary-$dpkgArch/Packages" 2>/dev/null  \
 			| tac|tac \
 			| awk -F ': ' '$1 == "Package" { pkg = $2; next } $1 == "Version" && pkg == "mariadb-server-'"$version"'" { print $2; exit }'
 	)"


### PR DESCRIPTION
`apt-transport-https` has been merged into `apt`