### PR TITLE
- fix MYSQL_ROOT_PASSWORD=127.0.0.1 case

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -147,6 +147,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			SET @@SESSION.SQL_LOG_BIN=0;
 
 			DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mysqlxsys', 'root') OR host NOT IN ('localhost') ;
+			FLUSH PRIVILEGES ;
 			SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${MYSQL_ROOT_PASSWORD}') ;
 			GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 			${rootCreate}


### PR DESCRIPTION
  Now DB initialization failed as CREATE USER operation fails because
  of https://bugs.mysql.com/bug.php?id=28331
  In short following sequence fails as FLUSH PRIVILEGES required in the middle:
      DELETE FROM mysql.user...;
      CREATE USER ...;
  As 127.0.0.1 already present container failed in related part of entrypoint