### PR TITLE
Added MYSQL_INIT_RETRIES_NUM env var

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -107,14 +107,14 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
-		for i in {30..0}; do
+		for i in $(seq 1 $MYSQL_INIT_RETRIES_NUM); do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
 				break
 			fi
 			echo 'MySQL init process in progress...'
 			sleep 1
 		done
-		if [ "$i" = 0 ]; then
+		if [ "$i" = $MYSQL_INIT_RETRIES_NUM ]; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi


### PR DESCRIPTION
Getting error "MySQL init process failed" consistently after MariaDB upgrade from 10.2.13 to 10.2.26. 
MariaDB stores its data in volumes mapped to NFS shared storage which is sometimes slow. 
Setting MYSQL_INIT_RETRIES_NUM environment variable to 120 fixed the issue. MariaDB init process has finished after almost 4 minutes. 
Relevant issue: https://github.com/docker-library/mariadb/issues/257
Such timeout is similar to MYSQL_START_TIMEOUT