### PR TITLE
Upgrade to MariaDB 10.3.23

### DIFF
--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -72,7 +72,7 @@ RUN set -ex; \
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le
 ENV MARIADB_MAJOR 10.3
-ENV MARIADB_VERSION 1:10.3.22+maria~bionic
+ENV MARIADB_VERSION 1:10.3.23+maria~bionic
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 


### PR DESCRIPTION
The new release of MariaDB 10.3.23 has been released:
https://github.com/MariaDB/server/releases/tag/mariadb-10.3.23

This PR updates to this version.