### PR TITLE
Add support for bzip2 dump files

### DIFF
--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -45,12 +45,14 @@ RUN mkdir /docker-entrypoint-initdb.d
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "pbzip2" for .sql.bz2 docker-entrypoint-initdb.d files
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
 		xz-utils \
+		pbzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -69,10 +69,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -45,12 +45,14 @@ RUN mkdir /docker-entrypoint-initdb.d
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "pbzip2" for .sql.bz2 docker-entrypoint-initdb.d files
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
 		xz-utils \
+		pbzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -69,10 +69,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -45,12 +45,14 @@ RUN mkdir /docker-entrypoint-initdb.d
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "pbzip2" for .sql.bz2 docker-entrypoint-initdb.d files
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
 		xz-utils \
+		pbzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -69,10 +69,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -45,12 +45,14 @@ RUN mkdir /docker-entrypoint-initdb.d
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "pbzip2" for .sql.bz2 docker-entrypoint-initdb.d files
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
 		xz-utils \
+		pbzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -69,10 +69,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -45,12 +45,14 @@ RUN mkdir /docker-entrypoint-initdb.d
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "pbzip2" for .sql.bz2 docker-entrypoint-initdb.d files
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
 		xz-utils \
+		pbzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -69,10 +69,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -45,12 +45,14 @@ RUN mkdir /docker-entrypoint-initdb.d
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "pbzip2" for .sql.bz2 docker-entrypoint-initdb.d files
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		pwgen \
 		tzdata \
 		xz-utils \
+		pbzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -72,7 +72,7 @@ docker_process_init_files() {
 			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
 			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
 			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-	    *.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,10 +69,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+	    *.sql.bz2) mysql_note "$0: running $f"; pbzcat "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done


### PR DESCRIPTION
Hello,

`pbzip2` is a parallel bzip2 file compressor which uses multiple cores to speeds up things significantly, so it's perfect for adding support for `*.sql.bz2`.

I tried running update.sh but sadly it failed on my mac even with bash 5.0.17 installed with brew.