### PR TITLE
Allow setting bind-addresss via env

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -265,6 +265,13 @@ docker_setup_db() {
 	fi
 }
 
+mysql_set_config() {
+	if [ -n "${MYSQL_BIND_ADDRESS:-}" ]; then
+		sed -i "s|#bind-address=0.0.0.0|bin-address=${MYSQL_BIND_ADDRESS}|g" \
+		    "/etc/mysql/my.cnf"
+	fi
+}
+
 _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
@@ -300,6 +307,8 @@ _main() {
 	# skip setup if they aren't running mysqld or want an option that stops mysqld
 	if [ "$1" = 'mysqld' ] && ! _mysql_want_help "$@"; then
 		mysql_note "Entrypoint script for MySQL Server ${MARIADB_VERSION} started."
+		
+		mysql_set_config
 
 		mysql_check_config "$@"
 		# Load various environment variables


### PR DESCRIPTION
Using the database server as a container is great, but it currently only
works by either volume mounting the socket, which only works on the same
host or by entering the container, editing the config file and
restarting the db, but not the container [0]. As docker containers tend to
be ephemeral, these changes are lost of restart/update of the
container, and have to be repeated.

One solution is to copy the config file into the volume (/var/lib/mysql)
and volume mount the config file as well. But this makes the config
files to get out of sync, if one does not really care about the config
file and trusts the official docker image.

Alternatively the above solution could be forced, by changing
'/etc/mysql/my.cnf' into a symlink point to '/var/lib/mysql/my.cnf' and
copying a template '/usr/share/mysql/my.cnf.example' to
'/var/lb/mysql/my.cnf' for example. This still has the same drawback as
above.

The solution here, allows for the user to simply pass an environment
variable and if set, we replace it in the config file. For the user,
this is the most trivial way to host a mysql server. Obviously, this
also puts the responsibility with the user, however as this user forced,
the default remains the current 'more secure' way.

[0] https://mariadb.com/kb/en/installing-and-using-mariadb-via-docker/

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>