### PR TITLE
Speed up 10.4+ timezone initialization

### DIFF
--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -205,11 +205,21 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# Aria in 10.4+ is slow due to "transactional" (crash safety)
+		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# sed is for https://bugs.mysql.com/bug.php?id=20545
 		mysql_tzinfo_to_sql /usr/share/zoneinfo \
 			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -205,21 +205,24 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-		# Aria in 10.4+ is slow due to "transactional" (crash safety)
-		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo \
-			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
-			| docker_process_sql --dont-use-mysql-root-password --database=mysql
-			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
+		{
+			# Aria in 10.4+ is slow due to "transactional" (crash safety)
+			# https://jira.mariadb.org/browse/MDEV-23326
+			# https://github.com/docker-library/mariadb/issues/262
+			local tztables=( time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type )
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+			done
+
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo \
+				| sed 's/Local time zone must be set--see zic manual page/FCTY/'
+
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+			done
+		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -205,11 +205,21 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# Aria in 10.4+ is slow due to "transactional" (crash safety)
+		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# sed is for https://bugs.mysql.com/bug.php?id=20545
 		mysql_tzinfo_to_sql /usr/share/zoneinfo \
 			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -205,21 +205,24 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-		# Aria in 10.4+ is slow due to "transactional" (crash safety)
-		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo \
-			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
-			| docker_process_sql --dont-use-mysql-root-password --database=mysql
-			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
+		{
+			# Aria in 10.4+ is slow due to "transactional" (crash safety)
+			# https://jira.mariadb.org/browse/MDEV-23326
+			# https://github.com/docker-library/mariadb/issues/262
+			local tztables=( time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type )
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+			done
+
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo \
+				| sed 's/Local time zone must be set--see zic manual page/FCTY/'
+
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+			done
+		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -205,11 +205,21 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# Aria in 10.4+ is slow due to "transactional" (crash safety)
+		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# sed is for https://bugs.mysql.com/bug.php?id=20545
 		mysql_tzinfo_to_sql /usr/share/zoneinfo \
 			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -205,21 +205,24 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-		# Aria in 10.4+ is slow due to "transactional" (crash safety)
-		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo \
-			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
-			| docker_process_sql --dont-use-mysql-root-password --database=mysql
-			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
+		{
+			# Aria in 10.4+ is slow due to "transactional" (crash safety)
+			# https://jira.mariadb.org/browse/MDEV-23326
+			# https://github.com/docker-library/mariadb/issues/262
+			local tztables=( time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type )
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+			done
+
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo \
+				| sed 's/Local time zone must be set--see zic manual page/FCTY/'
+
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+			done
+		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -205,11 +205,21 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# Aria in 10.4+ is slow due to "transactional" (crash safety)
+		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# sed is for https://bugs.mysql.com/bug.php?id=20545
 		mysql_tzinfo_to_sql /usr/share/zoneinfo \
 			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -205,21 +205,24 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-		# Aria in 10.4+ is slow due to "transactional" (crash safety)
-		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo \
-			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
-			| docker_process_sql --dont-use-mysql-root-password --database=mysql
-			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
+		{
+			# Aria in 10.4+ is slow due to "transactional" (crash safety)
+			# https://jira.mariadb.org/browse/MDEV-23326
+			# https://github.com/docker-library/mariadb/issues/262
+			local tztables=( time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type )
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+			done
+
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo \
+				| sed 's/Local time zone must be set--see zic manual page/FCTY/'
+
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+			done
+		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -205,11 +205,21 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# Aria in 10.4+ is slow due to "transactional" (crash safety)
+		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# sed is for https://bugs.mysql.com/bug.php?id=20545
 		mysql_tzinfo_to_sql /usr/share/zoneinfo \
 			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -205,21 +205,24 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-		# Aria in 10.4+ is slow due to "transactional" (crash safety)
-		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo \
-			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
-			| docker_process_sql --dont-use-mysql-root-password --database=mysql
-			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
+		{
+			# Aria in 10.4+ is slow due to "transactional" (crash safety)
+			# https://jira.mariadb.org/browse/MDEV-23326
+			# https://github.com/docker-library/mariadb/issues/262
+			local tztables=( time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type )
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+			done
+
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo \
+				| sed 's/Local time zone must be set--see zic manual page/FCTY/'
+
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+			done
+		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -205,11 +205,21 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# Aria in 10.4+ is slow due to "transactional" (crash safety)
+		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# sed is for https://bugs.mysql.com/bug.php?id=20545
 		mysql_tzinfo_to_sql /usr/share/zoneinfo \
 			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
+		do
+			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -205,21 +205,24 @@ docker_process_sql() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-		# Aria in 10.4+ is slow due to "transactional" (crash safety)
-		# https://jira.mariadb.org/browse/MDEV-23326 / https://github.com/docker-library/mariadb/issues/262
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo \
-			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
-			| docker_process_sql --dont-use-mysql-root-password --database=mysql
-			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
-		for table in time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type
-		do
-			echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
-		done| docker_process_sql --dont-use-mysql-root-password --database=mysql
+		{
+			# Aria in 10.4+ is slow due to "transactional" (crash safety)
+			# https://jira.mariadb.org/browse/MDEV-23326
+			# https://github.com/docker-library/mariadb/issues/262
+			local tztables=( time_zone time_zone_leap_second time_zone_name time_zone_transition time_zone_transition_type )
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=0 */;"
+			done
+
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo \
+				| sed 's/Local time zone must be set--see zic manual page/FCTY/'
+
+			for table in "${tztables[@]}"; do
+				echo "/*!100400 ALTER TABLE $table TRANSACTIONAL=1 */;"
+			done
+		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password
 	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then


### PR DESCRIPTION
MariaDB-10.4 defaulted to Aria for system tables.

This introduced crash safety under the name of "transactional"
that was not previously in MyISAM.

The Aria implementation of checkpointing incurs significant
penalty on fuse-overlayfs that occurs significantly in
container environments, especially those without a
/var/lib/mysql volume.

We work around this penalty by disabling the crash
safety of timezone tables for the period of timezone
initialization.

Analysis and timings are in https://jira.mariadb.org/browse/MDEV-23326
and local tests show that 10.4 is only 0.8 seconds slower
than 10.3 on startup (6.8 seconds total).

Version specific comments are used to ensure that ALTER TABLE
statements aren't run on < 10.4 server versions.

closes #262

I'm unconvinced I can get any significant fix into MariaDB before the next release so this should close off a major issue for the next release(s).

This won't be the end of the story. Lets see if we can do all the docker_setup_db under docker_init_database_dir with a little upstream help and improve the statup time again.