### PR TITLE
Install rocksdb plugin

### DIFF
--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -108,7 +108,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -108,7 +108,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.7/Dockerfile
+++ b/10.7/Dockerfile
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.8/Dockerfile
+++ b/10.8/Dockerfile
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -108,7 +108,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -110,7 +110,7 @@ RUN set -ex; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y \
-		"mariadb-server=$MARIADB_VERSION" mariadb-backup socat \
+		"mariadb-server=$MARIADB_VERSION" mariadb-backup mariadb-plugin-rocksdb socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership


### PR DESCRIPTION
RocksDB engine is officially supported by MariaDB (https://mariadb.com/kb/en/getting-started-with-myrocks/), but the image does not have the plugin installed. Install it, so users will be able to load it if it's needed.