### PR TITLE
feat: add the option to specify delayed replication for MariaDB

### DIFF
--- a/10.11-ubi/docker-entrypoint.sh
+++ b/10.11-ubi/docker-entrypoint.sh
@@ -274,6 +274,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -469,7 +470,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -274,6 +274,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -469,7 +470,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -265,6 +265,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -460,7 +461,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/10.6-ubi/docker-entrypoint.sh
+++ b/10.6-ubi/docker-entrypoint.sh
@@ -266,6 +266,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -461,7 +462,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -266,6 +266,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -461,7 +462,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.1/docker-entrypoint.sh
+++ b/11.1/docker-entrypoint.sh
@@ -274,6 +274,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -469,7 +470,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -274,6 +274,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -469,7 +470,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.4-ubi/docker-entrypoint.sh
+++ b/11.4-ubi/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.4/docker-entrypoint.sh
+++ b/11.4/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.5-ubi/docker-entrypoint.sh
+++ b/11.5-ubi/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.5/docker-entrypoint.sh
+++ b/11.5/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.6-ubi/docker-entrypoint.sh
+++ b/11.6-ubi/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/11.6/docker-entrypoint.sh
+++ b/11.6/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/main-ubi/docker-entrypoint.sh
+++ b/main-ubi/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi

--- a/main/docker-entrypoint.sh
+++ b/main/docker-entrypoint.sh
@@ -276,6 +276,7 @@ docker_setup_env() {
 	file_env 'MARIADB_REPLICATION_USER'
 	file_env 'MARIADB_REPLICATION_PASSWORD'
 	file_env 'MARIADB_REPLICATION_PASSWORD_HASH'
+	file_env 'MARIADB_REPLICATION_DELAY' 0
 	# env variables related to master
 	file_env 'MARIADB_MASTER_HOST'
 	file_env 'MARIADB_MASTER_PORT' 3306
@@ -471,7 +472,7 @@ docker_setup_db() {
 			rplPasswordEscaped=$(docker_sql_escape_string_literal "${MARIADB_REPLICATION_PASSWORD}")
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
-			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
+			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10, MASTER_DELAY=$MARIADB_REPLICATION_DELAY;"
 			startReplica="START REPLICA;"
 		fi
 	fi


### PR DESCRIPTION
Delayed replication is very useful for testing various replication scenarios.