### PR TITLE
Configure host to be 'localhost' in healthchecks

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -359,7 +359,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nhost=localhost\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 


### PR DESCRIPTION
Not sure, what the exact condition is that this occurs, but on my system I get

ERROR 1045 (28000): Access denied for user 'healthcheck'@'172.17...' (using password: YES)

The healthcheck user is granted access only from localhost. So we should ensure that the host we query is indeed localhost.