### PR TITLE
feat: include tcmalloc (cf. MDEV-30889)

### DIFF
--- a/.test/run.sh
+++ b/.test/run.sh
@@ -634,6 +634,21 @@ else
 fi
 
 	;&
+	tcmalloc)
+
+if [ -n "$debarch" ]
+then
+	echo -e "Test: tcmalloc preload\n"
+	runandwait -e LD_PRELOAD="/usr/lib/$debarch-linux-gnu/libtcmalloc_minimal.so.4 /usr/lib64/libtcmalloc_minimal.so.4" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
+	docker exec -i --user mysql "$cid" /bin/grep 'tcmalloc' /proc/1/maps || die "expected to preload tcmalloc"
+
+
+	killoff
+else
+	echo -e "Test: tcmalloc skipped - unknown arch '$architecture'\n"
+fi
+
+	;&
 	mariadbupgrade)
 	docker volume rm m57 || echo "m57 already cleaned"
 	docker volume create m57

--- a/10.11-ubi/Dockerfile
+++ b/10.11-ubi/Dockerfile
@@ -66,7 +66,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Long Term Support
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -90,7 +90,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/10.6-ubi/Dockerfile
+++ b/10.6-ubi/Dockerfile
@@ -67,7 +67,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Long Term Support
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -91,7 +91,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/11.4-ubi/Dockerfile
+++ b/11.4-ubi/Dockerfile
@@ -66,7 +66,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Long Term Support
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -90,7 +90,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/11.4/Dockerfile
+++ b/11.4/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4t64" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4t64 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/11.8-ubi/Dockerfile
+++ b/11.8-ubi/Dockerfile
@@ -66,7 +66,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Long Term Support
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -90,7 +90,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/11.8/Dockerfile
+++ b/11.8/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4t64" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4t64 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/12.0-ubi/Dockerfile
+++ b/12.0-ubi/Dockerfile
@@ -66,7 +66,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Rolling
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -90,7 +90,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4t64" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4t64 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/12.1-ubi/Dockerfile
+++ b/12.1-ubi/Dockerfile
@@ -66,7 +66,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Rolling
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -90,7 +90,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/12.1/Dockerfile
+++ b/12.1/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4t64" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4t64 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/Dockerfile-ubi.template
+++ b/Dockerfile-ubi.template
@@ -67,7 +67,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:%%MARIADB_SUPPORT_TYPE%%
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -91,7 +91,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "%%TCMALLOC_UBUNTU_PKG_NAME%%" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		%%TCMALLOC_UBUNTU_PKG_NAME%% \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/main-ubi/Dockerfile
+++ b/main-ubi/Dockerfile
@@ -66,7 +66,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 # release-support-type:Unknown
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
-# missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)
+# missing pwgen(epel), jemalloc(epel), gperftools-libs(epel) (as entrypoint/user extensions)
 # procps, pv(epel) - missing dependencies of galera sst script
 # tzdata re-installed as only a fake version is part of the ubi-minimal base image.
 # https://fedoraproject.org/security
@@ -90,7 +90,7 @@ RUN set -eux ; \
 	unset GNUPGHOME ; \
 	microdnf update -y ; \
 	microdnf reinstall -y tzdata ; \
-	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc pwgen pv util-linux-core ; \
+	microdnf install --enablerepo=epel --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc gperftools-libs pwgen pv util-linux-core ; \
 	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera ; \
 	chmod ugo+rwx,o+t /run/mariadb ; \
 	microdnf install -y MariaDB-backup-${MARIADB_VERSION}  MariaDB-server-${MARIADB_VERSION} ; \

--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -15,6 +15,7 @@ ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
 # uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
 # sub   rsa4096 2016-03-30 [E]
 # install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "libtcmalloc-minimal4t64" as it may improve performance and fix memory fragmentation issues. Use with LD_PRELOAD
 # install "pwgen" for randomizing passwords
 # install "tzdata" for /usr/share/zoneinfo/
 # install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
@@ -27,6 +28,7 @@ RUN set -eux; \
 		gpg \
 		gpgv \
 		libjemalloc2 \
+		libtcmalloc-minimal4t64 \
 		pwgen \
 		tzdata \
 		xz-utils \

--- a/update.sh
+++ b/update.sh
@@ -71,6 +71,12 @@ update_version()
 		arches="amd64 arm64v8 ppc64le s390x"
 	fi
 
+	if [[ $suite = 'jammy' ]]; then
+		tcmallocUbuntuPkgName="libtcmalloc-minimal4"
+	else
+		tcmallocUbuntuPkgName="libtcmalloc-minimal4t64"
+	fi
+
 	cp "Dockerfile${ubi}.template" "${dir}/Dockerfile"
 
 	cp docker-entrypoint.sh healthcheck.sh "$dir/"
@@ -81,6 +87,7 @@ update_version()
 		-e 's!%%MARIADB_MAJOR%%!'"${version%-ubi}"'!g' \
 		-e 's!%%MARIADB_RELEASE_STATUS%%!'"$releaseStatus"'!g' \
 		-e 's!%%MARIADB_SUPPORT_TYPE%%!'"$supportType"'!g' \
+		-e 's!%%TCMALLOC_UBUNTU_PKG_NAME%%!'"$tcmallocUbuntuPkgName"'!g' \
 		-e 's!%%SUITE%%!'"$suite"'!g' \
 		-e 's!%%ARCHES%%! '"$arches"'!g' \
 		"$dir/Dockerfile"


### PR DESCRIPTION
We’ve been engaged in an ongoing discussion regarding spontaneous OOM (Out of Memory) kills in [MDEV-30889](https://jira.mariadb.org/browse/MDEV-30889). In our case, the root cause was gradual memory fragmentation triggered by nightly mariadb-dump backup runs. After extensive testing, the only effective solution was to use `tcmalloc` via `LD_PRELOAD`, which has proven stable and reliable in our production environment for over a year.

While the Docker images already include `jemalloc` as an alternative memory allocator, it did not resolve the fragmentation issues we encountered. After discussing the issue in MDEV-30889, I asked for an approval to submit a PR and it was green lit by @grooverdan.