### PR TITLE
feat(test): rework test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: GitHub CI
 
 on:
   pull_request:
-    branches-ignore:
-      - next
     paths-ignore:
       - examples
       - Dockerfile.template
@@ -13,8 +11,6 @@ on:
       - Containerfile.debug
       - Containerfile.debug-ubi
   push:
-    branches-ignore:
-      - next
     paths-ignore:
       - examples
       - Dockerfile.template

--- a/.test/lib.sh
+++ b/.test/lib.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# Shared test utilities for MariaDB Docker image tests
+# Sourced by run.sh — do not execute directly
+
+set -eo pipefail
+
+# Global state
+cid=""
+cname=""
+master_host=""
+netid=""
+tmpvol=""
+mariadb=mariadb
+
+# Cleanup helpers
+
+killoff() {
+	if [ -n "$cid" ]; then
+		docker kill "$cid" > /dev/null || true
+	fi
+	sleep 2
+	if [ -n "$cid" ]; then
+		docker rm -v -f "$cid" > /dev/null || true
+	fi
+	cid=""
+	if [ -n "$master_host" ]; then
+		cid=$master_host
+		master_host=""
+		killoff
+	fi
+	if [ -n "$netid" ]; then
+		docker network rm "$netid"
+		netid=
+	fi
+}
+
+die() {
+	[ -n "$cid" ] && docker logs "$cid"
+	[ -n "$tmpvol" ] && docker rm "$tmpvol"
+	[ -n "$master_host" ] && docker logs "$master_host"
+	killoff
+	echo "$@" >&2
+	exit 1
+}
+
+# Container lifecycle
+
+runandwait() {
+	local port_int
+	if [ -z "$cname" ]; then
+		cname="mariadbcontainer$RANDOM"
+	fi
+	if [ -z "$port" ]; then
+		cid="$(
+			docker run -d \
+				--name "$cname" --rm --publish 3306 "$@"
+		)"
+		port_int=3306
+	else
+		cid="$(
+			docker run -d \
+				--name "$cname" --rm "$@"
+		)"
+		port_int=$port
+	fi
+	waiting=${DOCKER_LIBRARY_START_TIMEOUT:-15}
+	echo "waiting to start..."
+	set +e +o pipefail
+	while [ "$waiting" -gt 0 ]; do
+		(( waiting-- ))
+		sleep 1
+		if ! docker exec -i "$cid" "$mariadb" -h localhost --protocol tcp -P "$port_int" -e 'select 1' 2>&1 | grep -F "Can't connect" > /dev/null; then
+			break
+		fi
+	done
+	set -eo pipefail
+	if [ "$waiting" -eq 0 ]; then
+		die 'timeout'
+	fi
+}
+
+# Client wrappers
+
+mariadbclient_tcp() {
+	docker exec -i \
+		"$cname" \
+		$mariadb \
+		--host 127.0.0.1 \
+		--protocol tcp \
+		--silent \
+		"$@"
+}
+
+mariadbclient() {
+	docker exec -i \
+		"$cname" \
+		$mariadb \
+		--silent \
+		"$@"
+}
+
+# Assertions / checks
+
+checkUserExistInMariaDB() {
+	if [ -z "$1" ]; then
+		return 1
+	fi
+
+	local user
+	user=$(mariadbclient --user root ${2:+--password=$2} -e "SELECT User FROM mysql.global_priv where User='$1';")
+	if [ -z "$user" ]; then
+		return 1
+	fi
+
+	return 0
+}
+
+# Reusable test building blocks
+
+checkReplication() {
+	mariadb_replication_user='foo'
+	local pass_str=
+	local pass=
+	if [ "$1" = 'MARIADB_REPLICATION_PASSWORD_HASH' ]; then
+		pass_str=MARIADB_REPLICATION_PASSWORD_HASH='*0FD9A3F0F816D076CF239580A68A1147C250EB7B'
+		pass='jane'
+	else
+		pass_str='MARIADB_REPLICATION_PASSWORD=foo123'
+		pass='foo123'
+	fi
+
+	netid="mariadbnetwork$RANDOM"
+	docker network create "$netid"
+
+	rootpass=consistent_and_checkcheckable
+	runandwait \
+		--network "$netid" \
+		-e MARIADB_REPLICATION_USER="$mariadb_replication_user" \
+		-e "$pass_str" \
+		-e MARIADB_DATABASE=replcheck \
+		-e MARIADB_ROOT_PASSWORD="${rootpass}" \
+		"$image" --server-id=3000 --log-bin --log-basename=my-mariadb
+
+	if checkUserExistInMariaDB $mariadb_replication_user "${rootpass}"; then
+		grants=$(mariadbclient_tcp -u $mariadb_replication_user -p$pass -e "SHOW GRANTS")
+		# shellcheck disable=SC2076
+		[[ "${grants/SLAVE/REPLICA}" =~ "GRANT REPLICATION REPLICA ON *.* TO \`$mariadb_replication_user\`@\`%\`" ]] || die "I wasn't created how I was expected: got $grants"
+
+		mariadbclient_tcp -u root --password="$rootpass" --batch --skip-column-names -e 'create table t1(i int)' replcheck
+		readarray -t vals < <(mariadbclient_tcp --password="$rootpass" -u root --batch --skip-column-names -e 'show master status\G' replcheck)
+		lastfile="${vals[1]}"
+		pos="${vals[2]}"
+		[[ "$lastfile" = my-mariadb-bin.00000[12] ]] || die "too many binlog files"
+		[ "$pos" -lt 500 ] || die 'binary log too big'
+		docker exec "$cid" ls -la /var/lib/mysql/my-mariadb-bin.000001
+		docker exec "$cid" sh -c '[ $(wc -c < /var/lib/mysql/my-mariadb-bin.000001 ) -gt 2500 ]' && die 'binary log 1 too big'
+		docker exec "$cid" sh -c "[ \$(wc -c < /var/lib/mysql/$lastfile ) -gt $pos ]" && die 'binary log 2 too big'
+
+		master_host=$cname
+		unset cname
+		master_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$master_host")
+		port=3307
+		runandwait \
+			--network "$netid" \
+			-e MARIADB_MASTER_HOST="$master_ip" \
+			-e MARIADB_ROOT_PASSWORD="${rootpass}" \
+			-e MARIADB_REPLICATION_USER="$mariadb_replication_user" \
+			-e MARIADB_REPLICATION_PASSWORD="$pass" \
+			-e MARIADB_HEALTHCHECK_GRANTS="REPLICA MONITOR" \
+			--health-cmd='healthcheck.sh --connect --innodb-initialized --replication_io --replication_sql --replication_seconds_behind_master=0 --replication' \
+			--health-interval=3s \
+			"$image" --server-id=3001 --port "${port}"
+		unset port
+
+		c="${DOCKER_LIBRARY_START_TIMEOUT:-10}"
+		until docker exec "$cid" healthcheck.sh --connect --replication_io --replication_sql --replication_seconds_behind_master=0 --replication || [ "$c" -eq 0 ]; do
+			sleep 1
+			c=$(( c - 1 ))
+		done
+
+		docker exec --user mysql -i \
+			"$cname" \
+			$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
+			-e 'SHOW SLAVE STATUS\G' || die 'error examining replica status'
+
+		mariadbclient -u root --password="$rootpass" --batch --skip-column-names replcheck -e 'show create table t1;' || die 'sample table not replicated'
+
+		killoff
+	else
+		die "User $mariadb_replication_user did not get created for replication mode master"
+	fi
+}
+
+galera_sst() {
+	if [ $galera -eq 0 ]; then
+		echo No galera
+		return 0
+	fi
+	if [ "$architecture" != amd64 ]; then
+		echo test is too slow if not run natively
+		return 0
+	fi
+	sst=$1
+
+	netid="mariadbnetwork$RANDOM"
+	docker network create "$netid"
+
+	cname="mariadbcontainer_donor$RANDOM"
+	runandwait \
+		--network "$netid" \
+		--env MARIADB_ROOT_PASSWORD=secret --env MARIADB_DATABASE=test --env MARIADB_USER=test --env MARIADB_PASSWORD=test \
+		"${image}" \
+		--wsrep-new-cluster --wsrep-provider=/usr/lib/libgalera_smm.so --wsrep_cluster_address=gcomm://"$cname" --binlog_format=ROW --innodb_autoinc_lock_mode=2 --wsrep_on=ON --wsrep_sst_method="$sst" --wsrep_sst_auth=root:secret
+	master_host=$cid
+	unset cname
+	ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$cid")
+	DOCKER_LIBRARY_START_TIMEOUT=$(( ${DOCKER_LIBRARY_START_TIMEOUT:-10} * 7 )) runandwait \
+		--network "$netid" \
+		--env MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
+		"${image}" \
+		--wsrep-provider=/usr/lib/libgalera_smm.so --wsrep_cluster_address=gcomm://"$ip" --binlog_format=ROW --innodb_autoinc_lock_mode=2 --wsrep_on=ON --wsrep_sst_method="$sst" --wsrep_sst_auth=root:secret
+
+	v=$(mariadbclient -u root -psecret -e 'select VARIABLE_VALUE from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME="WSREP_LOCAL_STATE"' || :)
+
+	waiting=${DOCKER_LIBRARY_START_TIMEOUT:-10}
+	set +e +o pipefail
+	while [ "$waiting" -gt 0 ] && [ "$v" != 4 ]; do
+		(( waiting-- ))
+		sleep 1
+		v=$(mariadbclient -u root -psecret -e 'select VARIABLE_VALUE from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME="WSREP_LOCAL_STATE"' || :)
+	done
+	set -eo pipefail
+	if [ "$v" != 4 ]; then
+		die 'timeout'
+	fi
+
+	killoff
+}
+
+# initdb helpers
+
+prepare_initdb() {
+	local initdb
+	initdb=$(mktemp -d)
+	chmod go+rx "${initdb}"
+	cp -a "$dir"/initdb.d/* "${initdb}"
+	chmod -R go+rX "${initdb}"
+	gzip "${initdb}"/*gz*
+	xz "${initdb}"/*xz*
+	zstd "${initdb}"/*zst*
+	echo "$initdb"
+}

--- a/.test/lib.sh
+++ b/.test/lib.sh
@@ -4,6 +4,10 @@
 
 set -eo pipefail
 
+# Variables set by run.sh (image/dir before sourcing, architecture/galera after)
+: "${image:?}" "${dir:?}"
+declare -g image dir architecture galera
+
 # Global state
 cid=""
 cname=""
@@ -192,7 +196,7 @@ checkReplication() {
 }
 
 galera_sst() {
-	if [ $galera -eq 0 ]; then
+	if [ "$galera" -eq 0 ]; then
 		echo No galera
 		return 0
 	fi

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -2,12 +2,6 @@
 
 # MariaDB Docker image test runner
 #
-# Usage:
-#   ./run.sh <image>             — run all tests
-#   ./run.sh <image> <test>      — run a single test (function name without test_ prefix)
-#   ./run.sh <image> --list      — list available tests
-#   ./run.sh -v <image>          — run tests in verbose mode
-
 # Tests are defined as test_* functions in tests/*.sh files.
 # Shared utilities live in lib.sh.
 
@@ -15,23 +9,72 @@ set -eo pipefail
 
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-# Parse flags
-verbose=0
-args=()
-for arg in "$@"; do
-	case "$arg" in
-		-v|--verbose) verbose=1 ;;
-		*) args+=("$arg") ;;
-	esac
-done
-set -- "${args[@]}"
+usage() {
+	cat <<-EOF
+	Usage: $0 [OPTIONS] <image> [test_name]
 
-if [ $# -eq 0 ]; then
-	echo "Usage: $0 [-v|--verbose] <image> [test_name|--list]" >&2
+	Run MariaDB Docker image tests.
+
+	Arguments:
+	  image        Container image hash or tag to test
+	  test_name    Run only this specific test (without the test_ prefix)
+
+	Options:
+	  -h, --help      Show this help message and exit
+	  -l, --list      List all available tests and exit
+	  -v, --verbose   Show full trace output for tests
+
+	Examples:
+	  $0 mariadb:latest                  Run all tests
+	  $0 -v mariadb:latest               Run all tests with verbose output
+	  $0 mariadb:latest replication      Run only the 'replication' test
+	  $0 --list mariadb:latest           List available tests
+	EOF
+}
+
+# Parse options
+verbose=0
+list_tests=0
+image=""
+test_name=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-h|--help)
+			usage
+			exit 0
+			;;
+		-l|--list)
+			list_tests=1
+			;;
+		-v|--verbose)
+			verbose=1
+			;;
+		-*)
+			echo "Unknown option: $1" >&2
+			usage >&2
+			exit 1
+			;;
+		*)
+			if [ -z "$image" ]; then
+				image="$1"
+			elif [ -z "$test_name" ]; then
+				test_name="$1"
+			else
+				echo "Unexpected argument: $1" >&2
+				usage >&2
+				exit 1
+			fi
+			;;
+	esac
+	shift
+done
+
+if [ -z "$image" ]; then
+	echo "Error: <image> argument is required." >&2
+	usage >&2
 	exit 1
 fi
-
-image="$1"
 
 # Build ordered test list 
 # Defines the canonical execution order. Each entry is a test_ function name
@@ -76,7 +119,7 @@ TEST_ORDER=(
 	mariadb_user_host
 )
 
-if [ "${2:-}" = "--list" ]; then
+if [ "$list_tests" -eq 1 ]; then
 	echo "Available tests:"
 	for t in "${TEST_ORDER[@]}"; do
 		echo "  $t"
@@ -161,25 +204,10 @@ run_test() {
 	fi
 }
 
-if [ -n "${2:-}" ] && [ "$2" != "all" ]; then
-	# Single test mode — also support the old fallthrough behavior:
-	# if the name matches, run from that point onward (like the original ;&)
-	found=0
-	for t in "${TEST_ORDER[@]}"; do
-		if [ "$t" = "$2" ]; then
-			found=1
-		fi
-		if [ "$found" -eq 1 ]; then
-			validate_test "$t"
-			run_test "$t"
-		fi
-	done
-
-	if [ "$found" -eq 0 ]; then
-		# Try as an exact single test
-		validate_test "$2"
-		run_test "$2"
-	fi
+if [ -n "$test_name" ] && [ "$test_name" != "all" ]; then
+	# Single test mode
+	validate_test "$test_name"
+	run_test "$test_name"
 else
 	# Run all tests
 	for t in "${TEST_ORDER[@]}"; do

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -6,12 +6,10 @@
 #   ./run.sh <image>             — run all tests
 #   ./run.sh <image> <test>      — run a single test (function name without test_ prefix)
 #   ./run.sh <image> --list      — list available tests
+#   ./run.sh -v <image>          — run tests in verbose mode
 
 # Tests are defined as test_* functions in tests/*.sh files.
 # Shared utilities live in lib.sh.
-#
-# Options:
-#   -v, --verbose          — show full test output (trace) for all tests
 
 set -eo pipefail
 

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -96,7 +96,7 @@ for f in "$dir"/tests/*.sh; do
 	source "$f"
 done
 
-#  Detect image capabilities 
+# Detect image capabilities
 
 architecture=$(docker image inspect --format '{{.Architecture}}' "$image")
 
@@ -189,8 +189,6 @@ else
 		run_test "$t"
 	done
 fi
-
-# Summary
 
 echo "══════════════════════════════════════════════════════════════"
 echo " Results: $passed passed, $failed failed"

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -127,6 +127,7 @@ if [ "$list_tests" -eq 1 ]; then
 	exit 0
 fi
 
+# shellcheck source=/dev/null
 source "$dir/lib.sh"
 
 # Ensure test fixtures are readable by the mysql user inside containers
@@ -139,12 +140,16 @@ done
 
 # Detect image capabilities
 
+# Used in sourced test files (e.g. tests/allocator.sh) and lib.sh
+# shellcheck disable=SC2034
 architecture=$(docker image inspect --format '{{.Architecture}}' "$image")
 
+# shellcheck disable=SC2034
 galera=0
 v=$(docker run --rm "$image" mariadb --version)
 if [[ $v =~ Distrib\ 1[01] ]] || [[ $v =~ Distrib\ 12.2 ]]; then
 	# MDEV-38744 ends galera for 12.3+
+	# shellcheck disable=SC2034
 	galera=1
 fi
 
@@ -167,7 +172,6 @@ validate_test() {
 
 passed=0
 failed=0
-skipped=0
 
 test_logfile=$(mktemp)
 trap 'rm -f "$test_logfile"; killoff' EXIT
@@ -175,7 +179,10 @@ trap 'rm -f "$test_logfile"; killoff' EXIT
 run_test() {
 	local name="$1"
 
+	# Used in sourced lib.sh functions (killoff, mariadb, etc.)
+	# shellcheck disable=SC2034
 	cname=""
+	# shellcheck disable=SC2034
 	cid=""
 	if [ "$verbose" -eq 1 ]; then
 		echo ""

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -11,13 +11,13 @@ dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 usage() {
 	cat <<-EOF
-	Usage: $0 [OPTIONS] <image> [test_name]
+	Usage: $0 [OPTIONS] <image> [test_name...]
 
 	Run MariaDB Docker image tests.
 
 	Arguments:
 	  image        Container image hash or tag to test
-	  test_name    Run only this specific test (without the test_ prefix)
+	  test_name    Run one or more specific tests (without the test_ prefix)
 
 	Options:
 	  -h, --help      Show this help message and exit
@@ -25,10 +25,11 @@ usage() {
 	  -v, --verbose   Show full trace output for tests
 
 	Examples:
-	  $0 mariadb:latest                  Run all tests
-	  $0 -v mariadb:latest               Run all tests with verbose output
-	  $0 mariadb:latest replication      Run only the 'replication' test
-	  $0 --list mariadb:latest           List available tests
+	  $0 mariadb:latest                        Run all tests
+	  $0 -v mariadb:latest                     Run all tests with verbose output
+	  $0 mariadb:latest replication            Run only the 'replication' test
+	  $0 mariadb:latest replication binlog     Run only the named tests
+	  $0 --list                                List available tests
 	EOF
 }
 
@@ -36,7 +37,7 @@ usage() {
 verbose=0
 list_tests=0
 image=""
-test_name=""
+test_names=()
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -58,23 +59,13 @@ while [ $# -gt 0 ]; do
 		*)
 			if [ -z "$image" ]; then
 				image="$1"
-			elif [ -z "$test_name" ]; then
-				test_name="$1"
 			else
-				echo "Unexpected argument: $1" >&2
-				usage >&2
-				exit 1
+				test_names+=("$1")
 			fi
 			;;
 	esac
 	shift
 done
-
-if [ -z "$image" ]; then
-	echo "Error: <image> argument is required." >&2
-	usage >&2
-	exit 1
-fi
 
 # Build ordered test list 
 # Defines the canonical execution order. Each entry is a test_ function name
@@ -125,6 +116,12 @@ if [ "$list_tests" -eq 1 ]; then
 		echo "  $t"
 	done
 	exit 0
+fi
+
+if [ -z "$image" ]; then
+	echo "Error: <image> argument is required." >&2
+	usage >&2
+	exit 1
 fi
 
 # shellcheck source=/dev/null
@@ -211,10 +208,11 @@ run_test() {
 	fi
 }
 
-if [ -n "$test_name" ] && [ "$test_name" != "all" ]; then
-	# Single test mode
-	validate_test "$test_name"
-	run_test "$test_name"
+if [ ${#test_names[@]} -gt 0 ]; then
+	for test_name in "${test_names[@]}"; do
+		validate_test "$test_name"
+		run_test "$test_name"
+	done
 else
 	# Run all tests
 	for t in "${TEST_ORDER[@]}"; do

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -1,51 +1,104 @@
 #!/bin/bash
+
+# MariaDB Docker image test runner
+#
+# Usage:
+#   ./run.sh <image>             — run all tests
+#   ./run.sh <image> <test>      — run a single test (function name without test_ prefix)
+#   ./run.sh <image> --list      — list available tests
+
+# Tests are defined as test_* functions in tests/*.sh files.
+# Shared utilities live in lib.sh.
+#
+# Options:
+#   -v, --verbose          — show full test output (trace) for all tests
+
 set -eo pipefail
 
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-if [ $# -eq 0 ]
-then
-	echo "An image argument is required" >&2
+# Parse flags
+verbose=0
+args=()
+for arg in "$@"; do
+	case "$arg" in
+		-v|--verbose) verbose=1 ;;
+		*) args+=("$arg") ;;
+	esac
+done
+set -- "${args[@]}"
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 [-v|--verbose] <image> [test_name|--list]" >&2
 	exit 1
 fi
 
 image="$1"
 
+# Build ordered test list 
+# Defines the canonical execution order. Each entry is a test_ function name
+# (without the prefix). Add new tests by appending to this array.
+
+TEST_ORDER=(
+	required_password
+	mysql_allow_empty_password_is_empty
+	mysql_allow_empty_password_is_clean
+	mysql_root_password_is_set
+	mysql_random_password_is_complex
+	mysql_random_password_is_different
+	mysql_root_host_sets_host
+	mysql_root_host_localhost
+	complex_passwords
+	mysql_initdb_skip_tzinfo_empty
+	mysql_initdb_skip_tzinfo_no_empty
+	secrets_via_file
+	docker_entrypoint_initdb
+	prefer_mariadb_names
+	mariadb_allow_empty_root_password_empty
+	mariadb_allow_empty_root_password_not_empty
+	mariadb_root_password_is_set
+	mariadb_root_password_is_complex
+	mariadb_root_password_is_different
+	mariadb_root_host_sets_host
+	mariadb_initdb_skip_tzinfo_empty
+	mariadb_initdb_skip_tzinfo_not_empty
+	jemalloc
+	tcmalloc
+	mariadbupgrade
+	encryption
+	binlog
+	validate_master_env
+	validate_replica_env
+	replication
+	replication_password_hash
+	password_hash
+	galera_mariadbbackup
+	galera_sst_rsync
+	backup_restore
+	mariadb_user_host
+)
+
+if [ "${2:-}" = "--list" ]; then
+	echo "Available tests:"
+	for t in "${TEST_ORDER[@]}"; do
+		echo "  $t"
+	done
+	exit 0
+fi
+
+source "$dir/lib.sh"
+
+# Ensure test fixtures are readable by the mysql user inside containers
+chmod -R go+rX "$dir"/initdb.d "$dir"/encryption "$dir"/encryption_conf "$dir"/initenc "$dir"/tls 2>/dev/null || true
+
+for f in "$dir"/tests/*.sh; do
+	# shellcheck source=/dev/null
+	source "$f"
+done
+
+#  Detect image capabilities 
+
 architecture=$(docker image inspect --format '{{.Architecture}}' "$image")
-
-killoff()
-{
-	if [ -n "$cid" ]; then
-	      docker kill "$cid" > /dev/null || true
-	fi
-	sleep 2
-	if [ -n "$cid" ]; then
-	       docker rm -v -f "$cid" > /dev/null || true
-	fi
-	cid=""
-	if [ -n "$master_host" ]; then
-		cid=$master_host
-		master_host=""
-		killoff
-	fi
-	if [ -n "$netid" ]; then
-		docker network rm "$netid"
-		netid=
-	fi
-}
-
-die()
-{
-	[ -n "$cid" ] && docker logs "$cid"
-	[ -n "$tmpvol" ] && docker rm "$tmpvol"
-	[ -n "$master_host" ] && docker logs "$master_host"
-	killoff
-        echo "$@" >&2
-        exit 1
-}
-trap "killoff" EXIT
-
-mariadb=mariadb
 
 galera=0
 v=$(docker run --rm "$image" mariadb --version)
@@ -54,955 +107,95 @@ if [[ $v =~ Distrib\ 1[01] ]] || [[ $v =~ Distrib\ 12.2 ]]; then
 	galera=1
 fi
 
-runandwait()
-{
-	local port_int
-	if [ -z "$cname" ]; then
-		cname="mariadbcontainer$RANDOM"
+# Enable xtrace only in verbose mode
+if [ "$verbose" -eq 1 ]; then
+	set -x
+fi
+
+# Validate requested test exists
+
+validate_test() {
+	local name="$1"
+	if ! declare -f "test_$name" > /dev/null 2>&1; then
+		echo "Test '$name' not found. Use --list to see available tests." >&2
+		exit 1
 	fi
-	if [ -z "$port" ]; then
-		cid="$(
-			docker run -d \
-				--name "$cname" --rm --publish 3306 "$@"
-		)"
-		port_int=3306
-	else
-		cid="$(
-			docker run -d \
-				--name "$cname" --rm "$@"
-		)"
-		port_int=$port
-	fi
-	waiting=${DOCKER_LIBRARY_START_TIMEOUT:-15}
-	echo "waiting to start..."
-	set +e +o pipefail +x
-	while [ "$waiting" -gt 0 ]
-	do
-		(( waiting-- ))
-		sleep 1
-		if ! docker exec -i "$cid" "$mariadb" -h localhost --protocol tcp -P "$port_int" -e 'select 1' 2>&1 | grep -F "Can't connect" > /dev/null
-		then
-			break
+}
+
+# Run a single test with status tracking
+
+passed=0
+failed=0
+skipped=0
+
+test_logfile=$(mktemp)
+trap 'rm -f "$test_logfile"; killoff' EXIT
+
+run_test() {
+	local name="$1"
+
+	cname=""
+	cid=""
+	if [ "$verbose" -eq 1 ]; then
+		echo ""
+		echo "=> Running: $name"
+		echo ""
+		if "test_$name"; then
+			echo "PASSED: $name"
+			(( passed++ )) || :
+		else
+			echo "FAILED: $name"
+			(( failed++ )) || :
 		fi
-        done
-	set -eo pipefail -x
-	if [ "$waiting" -eq 0 ]
-	then
-		die 'timeout'
-	fi
-}
-
-mariadbclient_tcp() {
-	docker exec -i \
-		"$cname" \
-		$mariadb \
-		--host 127.0.0.1 \
-		--protocol tcp \
-		--silent \
-		"$@"
-}
-
-mariadbclient() {
-	docker exec -i \
-		"$cname" \
-		$mariadb \
-		--silent \
-		"$@"
-}
-
-checkUserExistInMariaDB() {
-	if [ -z "$1" ] ; then
-		return 1
-	fi
-
-	local user
-	user=$(mariadbclient --user root ${2:+--password=$2} -e "SELECT User FROM mysql.global_priv where User='$1';")
-	if [ -z "$user" ] ; then
-		return 1
-	fi
-
-	return 0
-}
-
-checkReplication() {
-	mariadb_replication_user='foo'
-	local pass_str=
-	local pass=
-	if [ "$1" = 'MARIADB_REPLICATION_PASSWORD_HASH' ] ; then
-		pass_str=MARIADB_REPLICATION_PASSWORD_HASH='*0FD9A3F0F816D076CF239580A68A1147C250EB7B'
-		pass='jane'
+		echo
 	else
-		pass_str='MARIADB_REPLICATION_PASSWORD=foo123'
-		pass='foo123'
-	fi
-
-	netid="mariadbnetwork$RANDOM"
-	docker network create "$netid"
-
-	# When MARIADB_REPLICATION_HOST is not specified as env, and MARIADB_REPLICATION_USER exists, then considered as master container.
-	rootpass=consistent_and_checkcheckable
-	runandwait \
-		--network "$netid" \
-		-e MARIADB_REPLICATION_USER="$mariadb_replication_user" \
-		-e "$pass_str" \
-		-e MARIADB_DATABASE=replcheck \
-		-e MARIADB_ROOT_PASSWORD="${rootpass}" \
-		"$image" --server-id=3000 --log-bin --log-basename=my-mariadb
-
-	# Checks $mariadb_replication_user get created or not
-	if checkUserExistInMariaDB $mariadb_replication_user  "${rootpass}"; then
-		grants=$(mariadbclient_tcp -u $mariadb_replication_user -p$pass -e "SHOW GRANTS")
-		# shellcheck disable=SC2076
-		[[ "${grants/SLAVE/REPLICA}" =~ "GRANT REPLICATION REPLICA ON *.* TO \`$mariadb_replication_user\`@\`%\`" ]] || die "I wasn't created how I was expected: got $grants"
-
-		mariadbclient_tcp -u root --password="$rootpass" --batch --skip-column-names -e 'create table t1(i int)' replcheck
-		readarray -t vals < <(mariadbclient_tcp --password="$rootpass" -u root --batch --skip-column-names -e 'show master status\G' replcheck)
-		lastfile="${vals[1]}"
-		pos="${vals[2]}"
-		[[ "$lastfile" = my-mariadb-bin.00000[12] ]] || die "too many binlog files"
-		[ "$pos" -lt 500 ] || die 'binary log too big'
-		docker exec "$cid" ls -la /var/lib/mysql/my-mariadb-bin.000001
-		docker exec "$cid" sh -c '[ $(wc -c < /var/lib/mysql/my-mariadb-bin.000001 ) -gt 2500 ]' && die 'binary log 1 too big'
-		docker exec "$cid" sh -c "[ \$(wc -c < /var/lib/mysql/$lastfile ) -gt $pos ]" && die 'binary log 2 too big'
-
-		master_host=$cname
-		unset cname
-		master_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$master_host")
-		port=3307
-		runandwait \
-			--network "$netid" \
-			-e MARIADB_MASTER_HOST="$master_ip" \
-		        -e MARIADB_ROOT_PASSWORD="${rootpass}" \
-			-e MARIADB_REPLICATION_USER="$mariadb_replication_user" \
-			-e MARIADB_REPLICATION_PASSWORD="$pass" \
-			-e MARIADB_HEALTHCHECK_GRANTS="REPLICA MONITOR" \
-			--health-cmd='healthcheck.sh --connect --innodb-initialized --replication_io --replication_sql --replication_seconds_behind_master=0 --replication' \
-			--health-interval=3s \
-			"$image" --server-id=3001 --port "${port}"
-		unset port
-
-		c="${DOCKER_LIBRARY_START_TIMEOUT:-10}"
-		until docker exec "$cid" healthcheck.sh --connect --replication_io --replication_sql --replication_seconds_behind_master=0 --replication || [ "$c" -eq 0 ]
-		do
-			sleep 1
-			c=$(( c - 1 ))
-		done
-
-		docker exec --user mysql -i \
-			"$cname" \
-			$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
-			-e 'SHOW SLAVE STATUS\G' || die 'error examining replica status'
-
-		mariadbclient -u root --password="$rootpass" --batch --skip-column-names replcheck -e 'show create table t1;' || die 'sample table not replicated'
-
-		killoff
-	else
-		die "User $mariadb_replication_user did not get created for replication mode master"
+		printf '=> %-45s ' "$name"
+		if ( set -x; "test_$name" ) > "$test_logfile" 2>&1; then
+			echo "PASSED"
+			(( passed++ )) || :
+		else
+			echo "FAILED"
+			echo " test output "
+			cat "$test_logfile"
+			echo " end output ─"
+			(( failed++ )) || :
+		fi
 	fi
 }
 
-galera_sst()
-{
-	if [ $galera -eq 0 ]; then
-		echo No galera
-		return 0
-	fi
-        if [ "$architecture" != amd64 ]; then
-		echo test is too slow if not run natively
-		return 0
-	fi
-	sst=$1
-
-	netid="mariadbnetwork$RANDOM"
-	docker network create "$netid"
-
-	cname="mariadbcontainer_donor$RANDOM"
-	runandwait \
-		--network "$netid" \
-		--env MARIADB_ROOT_PASSWORD=secret  --env MARIADB_DATABASE=test  --env MARIADB_USER=test --env MARIADB_PASSWORD=test \
-		"${image}"\
-		--wsrep-new-cluster --wsrep-provider=/usr/lib/libgalera_smm.so --wsrep_cluster_address=gcomm://"$cname" --binlog_format=ROW --innodb_autoinc_lock_mode=2 --wsrep_on=ON --wsrep_sst_method="$sst" --wsrep_sst_auth=root:secret
-	master_host=$cid
-	unset cname
-	ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$cid")
-	DOCKER_LIBRARY_START_TIMEOUT=$(( ${DOCKER_LIBRARY_START_TIMEOUT:-10} * 7 )) runandwait \
-		--network "$netid" \
-		--env MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
-		"${image}" \
-		--wsrep-provider=/usr/lib/libgalera_smm.so  --wsrep_cluster_address=gcomm://"$ip" --binlog_format=ROW --innodb_autoinc_lock_mode=2 --wsrep_on=ON --wsrep_sst_method="$sst" --wsrep_sst_auth=root:secret
-
-	v=$(mariadbclient -u root -psecret -e 'select VARIABLE_VALUE from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME="WSREP_LOCAL_STATE"' || :)
-
-	waiting=${DOCKER_LIBRARY_START_TIMEOUT:-10}
-	set +e +o pipefail +x
-	while [ "$waiting" -gt 0 ] && [ "$v" != 4 ]
-	do
-		(( waiting-- ))
-		sleep 1
-		v=$(mariadbclient -u root -psecret -e 'select VARIABLE_VALUE from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME="WSREP_LOCAL_STATE"' || :)
-        done
-	set -eo pipefail -x
-	if [ "$v" != 4 ]
-	then
-		die 'timeout'
-	fi
-
-	killoff
-}
-
-case ${2:-all} in
-	all|required_password)
-
-echo -e "Test: expect Failure - none of MYSQL_ALLOW_EMPTY_PASSWORD, MYSQL_RANDOM_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD\n"
-
-cname="mariadb-container-fail-to-start-options-$RANDOM-$RANDOM"
-docker run --name "$cname" --rm "$image" 2>&1 && die "$cname should fail with unspecified option"
-
-	;&
-	mysql_allow_empty_password_is_empty)
-
-echo -e "Test: MYSQL_ALLOW_EMPTY_PASSWORD Implementation is empty value so this should fail\n"
-docker run  --rm  --name "$cname" -e MYSQL_ALLOW_EMPTY_PASSWORD  "$image" && die "$cname should fail with empty MYSQL_ALLOW_EMPTY_PASSWORD"
-echo 'expected failure of empty MYSQL_ALLOW_EMPTY_PASSWORD'
-
-	;&
-	mysql_allow_empty_password_is_clean)
-
-echo -e "Test: MYSQL_ALLOW_EMPTY_PASSWORD and defaults to clean environment, +default-storage-engine=InnoDB\n"
-
-runandwait -e MYSQL_ALLOW_EMPTY_PASSWORD=1 "${image}" --default-storage-engine=InnoDB
-mariadbclient -u root -e 'show databases'
-
-othertables=$(mariadbclient -u root --skip-column-names -Be "select group_concat(SCHEMA_NAME) from information_schema.SCHEMATA where SCHEMA_NAME not in ('mysql', 'information_schema', 'performance_schema', 'sys')")
-[ "${othertables}" != 'NULL' ] && die "unexpected table(s) $othertables"
-
-otherusers=$(mariadbclient -u root --skip-column-names -Be "select user,host from mysql.global_priv where (user,host) not in (('root', 'localhost'), ('root', '%'), ('mariadb.sys', 'localhost'), ('healthcheck', '::1'), ('healthcheck', '127.0.0.1'), ('healthcheck', 'localhost'))")
-[ "$otherusers" != '' ] && die "unexpected users $otherusers"
-
-	echo "Contents of /var/lib/mysql/{mysql,mariadb}_upgrade_info:"
-	docker exec "$cid" cat /var/lib/mysql/mysql_upgrade_info \
-		|| docker exec "$cid" cat /var/lib/mysql/mariadb_upgrade_info \
-		|| die "missing {mariadb,mysql_upgrade}_info on install"
-	echo
-
-killoff
-
-	;&
-	mysql_root_password_is_set)
-
-	echo -e "Test: MYSQL_ROOT_PASSWORD and mysql@localhost user\n"
-
-	runandwait -e MYSQL_ROOT_PASSWORD=examplepass -e MARIADB_MYSQL_LOCALHOST_USER=1 "${image}"
-	mariadbclient -u root -pexamplepass -e 'select current_user()'
-	mariadbclient -u root -pwrongpass -e 'select current_user()' || echo 'expected failure'
-
-	otherusers=$(mariadbclient -u root -pexamplepass --skip-column-names -Be "select user,host from mysql.global_priv where (user,host) not in (('root', 'localhost'), ('root', '%'), ('mariadb.sys', 'localhost'), ('mysql','localhost'), ('healthcheck', '::1'), ('healthcheck', '127.0.0.1'), ('healthcheck', 'localhost'))")
-	[ "$otherusers" != '' ] && die "unexpected users $otherusers"
-
-	createuser=$(docker exec --user mysql -i \
-		"$cname" \
-		$mariadb \
-		--silent \
-		-e "show create user")
-	# shellcheck disable=SC2016
-	[ "${createuser//\'/\`}" == 'CREATE USER `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "mysql@localhost wasn't created how I was expected"
-
-	grants="$(docker exec --user mysql -i \
-		"$cname" \
-		$mariadb \
-		--silent \
-		-e show\ grants)"
-
-	# shellcheck disable=SC2016
-	[ "${grants//\'/\`}" == 'GRANT USAGE ON *.* TO `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "mysql@localhost wasn't granted what I was expected"
-
-	createuser=$(docker exec --user mysql -i \
-		"$cname" \
-		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
-		--silent \
-		-e "show create user")
-	# shellcheck disable=SC2016,SC2076
-	[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`localhost` IDENTIFIED' ]] || \
-		[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`::1` IDENTIFIED' ]] || \
-		[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`127.0.0.1` IDENTIFIED' ]] || die "healthcheck wasn't created how I was expected"
-
-	grants="$(docker exec --user mysql -i \
-		"$cname" \
-		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
-		--silent \
-		-e show\ grants)"
-
-	[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`localhost\` ]] || \
-		[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`::1\` ]] || \
-		[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`127.0.0.1\` ]] || die "healthcheck wasn't granted what I was expected"
-	killoff
-
-	;&
-	mysql_random_password_is_complex)
-
-echo -e "Test: MYSQL_RANDOM_ROOT_PASSWORD, needs to satisfy minimum complexity of simple-password-check plugin and old-mode=''\n"
-
-runandwait -e MYSQL_RANDOM_ROOT_PASSWORD=1 -e MARIADB_MYSQL_LOCALHOST_USER=1 -e MARIADB_MYSQL_LOCALHOST_GRANTS="RELOAD, PROCESS, LOCK TABLES" \
-	"${image}" --plugin-load-add=simple_password_check --old-mode=""
-pass=$(docker logs "$cid" | grep 'GENERATED ROOT PASSWORD' 2>&1)
-# trim up until passwod
-pass=${pass#*GENERATED ROOT PASSWORD: }
-mariadbclient -u root -p"${pass}" -e 'select current_user()'
-
-	docker exec --user mysql -i \
-		"$cname" \
-		$mariadb \
-		--silent \
-		-e "select 'I connect therefore I am'" || die "I'd hoped to work around MDEV-24111"
-
-	grants="$(docker exec --user mysql -i \
-		"$cname" \
-		$mariadb \
-		--silent \
-		-e show\ grants)"
-
-	# shellcheck disable=SC2016
-	[ "${grants//\'/\`}" == 'GRANT RELOAD, PROCESS, LOCK TABLES ON *.* TO `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "I wasn't granted what I was expected"
-
-	killoff
-
-	;&
-	mysql_random_password_is_different)
-
-echo -e "Test: second instance of MYSQL_RANDOM_ROOT_PASSWORD has a different password (and mysql@localhost can be created(\n"
-
-runandwait -e MYSQL_RANDOM_ROOT_PASSWORD=1 -e MARIADB_MYSQL_LOCALHOST_USER=1 "${image}" --plugin-load-add=simple_password_check
-newpass=$(docker logs "$cid" | grep 'GENERATED ROOT PASSWORD' 2>&1)
-# trim up until passwod
-newpass=${newpass#*GENERATED ROOT PASSWORD: }
-mariadbclient -u root -p"${newpass}" -e 'select current_user()'
-killoff
-
-[ "$pass" = "$newpass" ] && die "highly improbable - two consecutive passwords are the same"
-
-	;&
-	mysql_root_host_sets_host)
-
-echo -e "Test: MYSQL_ROOT_HOST\n"
-
-runandwait -e  MYSQL_ALLOW_EMPTY_PASSWORD=1  -e MYSQL_ROOT_HOST=apple "${image}"
-ru=$(mariadbclient --skip-column-names -B -u root -e 'select user,host from mysql.global_priv where host="apple"')
-[ "${ru}" = '' ] && die 'root@apple not created'
-killoff
-
-	;&
-	mysql_root_host_localhost)
-
-echo -e "Test: MYSQL_ROOT_HOST=localhost\n"
-
-runandwait -e  MARIADB_ROOT_PASSWORD=bob  -e MYSQL_ROOT_HOST=localhost "${image}"
-ru=$(mariadbclient --skip-column-names -B -u root -pbob -e 'select user,host from mysql.global_priv where user="root" and host="localhost"')
-[ "${ru}" = '' ] && die 'root@localhost not created'
-killoff
-
-	;&
-	complex_passwords)
-
-echo -e "Test: complex passwords\n"
-
-runandwait -e MYSQL_USER=bob -e MYSQL_PASSWORD=$'\n $\' \n' -e MYSQL_ROOT_PASSWORD=$'\n\'\\aa-\x09-zz"_%\n' \
-	-e MARIADB_REPLICATION_USER="foo" \
-	-e MARIADB_REPLICATION_PASSWORD=$'\n\'\\aa-\x09-zz"_%\n' \
-	"${image}"
-mariadbclient --skip-column-names -B -u root -p$'\n\'\\aa-\x09-zz"_%\n' -e 'select 1'
-mariadbclient --skip-column-names -B -u foo -p$'\n\'\\aa-\x09-zz"_%\n' -e 'select 1'
-mariadbclient --skip-column-names -B -u bob -p$'\n $\' \n' -e 'select 1'
-killoff
-
-	;&
-	mysql_initdb_skip_tzinfo_empty)
-
-echo -e "Test: MYSQL_INITDB_SKIP_TZINFO='' should still load timezones\n"
-
-# ONLY_FULL_GROUP_BY - test for MDEV-29347
-runandwait -e MYSQL_INITDB_SKIP_TZINFO= -e MYSQL_ALLOW_EMPTY_PASSWORD=1 "${image}" --default-time-zone=Europe/Berlin --sql-mode=ONLY_FULL_GROUP_BY
-tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
-[ "${tzcount}" = '0' ] && die "should exist timezones"
-[ "$(mariadbclient --skip-column-names -B -u root -e 'SELECT @@time_zone')" != "Europe/Berlin" ] && die "Didn't set timezone to Berlin"
-killoff
-
-	;&
-	mysql_initdb_skip_tzinfo_no_empty)
-
-echo -e "Test: MYSQL_INITDB_SKIP_TZINFO=1 should not load timezones\n"
-
-runandwait -e MYSQL_INITDB_SKIP_TZINFO=1 -e MYSQL_ALLOW_EMPTY_PASSWORD=1 "${image}"
-tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
-[ "${tzcount}" = '0' ] || die "timezones shouldn't be loaded - found ${tzcount}"
-killoff
-
-	;&
-	secrets_via_file)
-
-echo -e "Test: Secrets _FILE vars should be same as env directly\n"
-
-secretdir=$(mktemp -d)
-chmod go+rx "${secretdir}"
-echo bob > "$secretdir"/pass
-echo pluto > "$secretdir"/host
-echo titan > "$secretdir"/db
-echo ron > "$secretdir"/u
-echo '*D87991C62A9CAEDC4AE0F608F19173AC7E614952' > "$secretdir"/p
-
-tmpvol=v$RANDOM
-docker volume create "$tmpvol"
-# any container will work with tar in it, we may well use the image we have
-(cd "$secretdir" ; tar -cf - .) | docker run --rm --volume "$tmpvol":/v --user root -i "${image}" tar -xf - -C /v
-rm -rf "${secretdir}"
-
-runandwait \
-	-v "$tmpvol":/run/secrets \
-	-e MYSQL_ROOT_PASSWORD_FILE=/run/secrets/pass \
-	-e MYSQL_ROOT_HOST_FILE=/run/secrets/host \
-	-e MYSQL_DATABASE_FILE=/run/secrets/db \
-	-e MYSQL_USER_FILE=/run/secrets/u \
-	-e MARIADB_PASSWORD_HASH_FILE=/run/secrets/p \
-	"${image}"
-
-host=$(mariadbclient --skip-column-names -B -u root -pbob -e 'select host from mysql.global_priv where user="root" and host="pluto"' titan)
-[ "${host}" != 'pluto' ] && die 'root@pluto not created'
-creation=$(mariadbclient --skip-column-names -B -u ron -pscappers -P 3306 --protocol tcp titan -e "CREATE TABLE landing(i INT)")
-[ "${creation}" = '' ] || die 'creation error'
-killoff
-docker volume rm "$tmpvol"
-tmpvol=
-
-	;&
-	docker_entrypint_initdb)
-
-echo -e "Test: docker-entrypoint-initdb.d Initialization order is correct and processed\n"
-
-initdb=$(mktemp -d)
-chmod go+rx "${initdb}"
-cp -a "$dir"/initdb.d/* "${initdb}"
-gzip "${initdb}"/*gz*
-xz "${initdb}"/*xz*
-zstd "${initdb}"/*zst*
-
-runandwait \
-        -v "${initdb}":/docker-entrypoint-initdb.d:Z \
-	-e MYSQL_ROOT_PASSWORD=ssh \
-	-e MYSQL_DATABASE=titan \
-	-e MYSQL_USER=ron \
-	-e MYSQL_PASSWORD=scappers \
-	"${image}" 
-
-init_sum=$(mariadbclient --skip-column-names -B -u ron -pscappers -P 3306 -h 127.0.0.1  --protocol tcp titan -e "select sum(i) from t1;")
-[ "${init_sum}" = '1833' ] || die 'initialization order error'
-killoff
-rm -rf "${initdb}"
-
-
-	;&
-	prefer_mariadb_names)
-
-echo -e "Test: when provided with MYSQL_ and MARIADB_ names, Prefer MariaDB names\n"
-
-runandwait -e MARIADB_ROOT_PASSWORD=examplepass -e MYSQL_ROOT_PASSWORD=mysqlexamplepass "${image}"
-mariadbclient -u root -pexamplepass -e 'select current_user()'
-mariadbclient -u root -pwrongpass -e 'select current_user()' || echo 'expected failure of wrong password'
-killoff
-
-	;&
-	mariadb_allow_empty_root_password_empty)
-
-echo -e "Test: MARIADB_ALLOW_EMPTY_ROOT_PASSWORD Implementation is empty value so this should fail\n"
-
-docker run  --rm  --name "$cname" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD "$image" || echo 'expected failure MARIADB_ALLOW_EMPTY_ROOT_PASSWORD is empty'
-
-	;&
-	mariadb_allow_empty_root_password_not_empty)
-
-echo -e "Test: MARIADB_ALLOW_EMPTY_ROOT_PASSWORD\n"
-
-# +Defaults to clean environment
-runandwait -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
-mariadbclient -u root -e 'show databases'
-
-othertables=$(mariadbclient -u root --skip-column-names -Be "select group_concat(SCHEMA_NAME) from information_schema.SCHEMATA where SCHEMA_NAME not in ('mysql', 'information_schema', 'performance_schema', 'sys')")
-[ "${othertables}" != 'NULL' ] && die "unexpected table(s) $othertables"
-
-otherusers=$(mariadbclient -u root --skip-column-names -Be "select user,host from mysql.global_priv where (user,host) not in (('root', 'localhost'), ('root', '%'), ('mariadb.sys', 'localhost'), ('mysql','localhost'), ('healthcheck', '::1'), ('healthcheck', '127.0.0.1'), ('healthcheck', 'localhost'))")
-[ "$otherusers" != '' ] && die "unexpected users $otherusers"
-killoff
-
-	;&
-	mariadb_root_password_is_set)
-
-echo -e "Test: MARIADB_ROOT_PASSWORD\n"
-
-runandwait -e MARIADB_ROOT_PASSWORD=examplepass "${image}"
-mariadbclient -u root -pexamplepass -e 'select current_user()'
-mariadbclient -u root -pwrongpass -e 'select current_user()' || echo 'expected failure' 
-killoff
-
-	;&
-	mariadb_root_password_is_complex)
-
-echo -e "Test: MARIADB_RANDOM_ROOT_PASSWORD, needs to satisfy minimum complexity of simple-password-check plugin\n"
-
-runandwait -e MARIADB_RANDOM_ROOT_PASSWORD=1 "${image}" --plugin-load-add=simple_password_check
-pass=$(docker logs "$cid"  2>&1 | grep 'GENERATED ROOT PASSWORD')
-# trim up until passwod
-pass=${pass#*GENERATED ROOT PASSWORD: }
-mariadbclient -u root -p"${pass}" -e 'select current_user()'
-killoff
-
-	;&
-	mariadb_root_password_is_different)
-
-echo -e "Test: second instance of MARIADB_RANDOM_ROOT_PASSWORD has a different password\n"
-
-runandwait -e MARIADB_RANDOM_ROOT_PASSWORD=1 "${image}" --plugin-load-add=simple_password_check
-newpass=$(docker logs "$cid"  2>&1 | grep 'GENERATED ROOT PASSWORD')
-# trim up until password
-newpass=${newpass#*GENERATED ROOT PASSWORD: }
-mariadbclient -u root -p"${newpass}" -e 'select current_user()'
-killoff
-
-[ "$pass" = "$newpass" ] && die "highly improbable - two consecutive random passwords are the same"
-
-	;&
-	mariadb_root_host_sets_host)
-
-echo -e "Test: MARIADB_ROOT_HOST\n"
-
-runandwait -e  MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1  -e MARIADB_ROOT_HOST=apple "${image}"
-ru=$(mariadbclient --skip-column-names -B -u root -e 'select user,host from mysql.global_priv where host="apple"')
-[ "${ru}" = '' ] && die 'root@apple not created'
-killoff
-
-	;&
-	mariadb_initdb_skip_tzinfo_empty)
-
-echo -e "Test: MARIADB_INITDB_SKIP_TZINFO=''\n"
-
-runandwait -e MARIADB_INITDB_SKIP_TZINFO= -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
-tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
-[ "${tzcount}" = '0' ] && die "should exist time zones"
-
-# note uses previous instance
-echo -e "Test: default configuration items are present\n"
-arg_expected=0
-docker exec -i "$cid" my_print_defaults --mysqld |
-	{
-	while read -r line
-	do
-		case $line in
-		--host-cache-size=0|--skip-name-resolve)
-			echo "$line" found
-			(( arg_expected++ )) || : ;;
-		esac
+if [ -n "${2:-}" ] && [ "$2" != "all" ]; then
+	# Single test mode — also support the old fallthrough behavior:
+	# if the name matches, run from that point onward (like the original ;&)
+	found=0
+	for t in "${TEST_ORDER[@]}"; do
+		if [ "$t" = "$2" ]; then
+			found=1
+		fi
+		if [ "$found" -eq 1 ]; then
+			validate_test "$t"
+			run_test "$t"
+		fi
 	done
-	[ "$arg_expected" -eq 2 ] || die "expected both host-cache-size=0 and skip-name-resolve"
-}
-killoff
 
-	;&
-	mariadb_initdb_skip_tzinfo_not_empty)
-
-echo -e "Test: MARIADB_INITDB_SKIP_TZINFO=1\n"
-
-runandwait -e MARIADB_INITDB_SKIP_TZINFO=1 -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
-tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
-[ "${tzcount}" = '0' ] || die "timezones shouldn't be loaded - found ${tzcount}"
-killoff
-
-	;&
-	jemalloc)
-
-case "$architecture" in
-	amd64)
-		debarch=x86_64 ;;
-	arm64)
-		debarch=aarch64 ;;
-	ppc64le)
-		debarch=powerpc64le ;;
-	s390x|i386|*)
-		debarch=$architecture ;;
-esac
-if [ -n "$debarch" ]
-then
-	echo -e "Test: jemalloc preload\n"
-	runandwait -e LD_PRELOAD="/usr/lib/$debarch-linux-gnu/libjemalloc.so.1 /usr/lib/$debarch-linux-gnu/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
-	docker exec -i --user mysql "$cid" /bin/grep 'jemalloc' /proc/1/maps || die "expected to preload jemalloc"
-
-
-	killoff
+	if [ "$found" -eq 0 ]; then
+		# Try as an exact single test
+		validate_test "$2"
+		run_test "$2"
+	fi
 else
-	echo -e "Test: jemalloc skipped - unknown arch '$architecture'\n"
+	# Run all tests
+	for t in "${TEST_ORDER[@]}"; do
+		validate_test "$t"
+		run_test "$t"
+	done
 fi
 
-	;&
-	tcmalloc)
+# Summary
 
-if [ -n "$debarch" ]
-then
-	echo -e "Test: tcmalloc preload\n"
-	runandwait -e LD_PRELOAD="/usr/lib/$debarch-linux-gnu/libtcmalloc_minimal.so.4 /usr/lib64/libtcmalloc_minimal.so.4" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
-	docker exec -i --user mysql "$cid" /bin/grep 'tcmalloc' /proc/1/maps || die "expected to preload tcmalloc"
+echo "══════════════════════════════════════════════════════════════"
+echo " Results: $passed passed, $failed failed"
+echo "══════════════════════════════════════════════════════════════"
 
-
-	killoff
-else
-	echo -e "Test: tcmalloc skipped - unknown arch '$architecture'\n"
-fi
-
-	;&
-	mariadbupgrade)
-	docker volume rm m57 || echo "m57 already cleaned"
-	docker volume create m57
-	docker pull docker.io/library/mysql:5.7
-	mariadb=mysql runandwait -v m57:/var/lib/mysql:Z -e MYSQL_INITDB_SKIP_TZINFO=1 -e MYSQL_ROOT_PASSWORD=bob docker.io/library/mysql:5.7
-	# clean shutdown required
-	docker exec "$cid" mysql -u root -pbob -e "set global innodb_fast_shutdown=0;SHUTDOWN"
-	while docker exec "$cid" ls -lad /proc/1; do
-		sleep 1
-	done
-
-	# tls test to ensure that #592 is resolved
-	DOCKER_LIBRARY_START_TIMEOUT=$(( ${DOCKER_LIBRARY_START_TIMEOUT:-10} * 7 )) runandwait -e MARIADB_AUTO_UPGRADE=1 -v "${dir}"/tls:/etc/mysql/conf.d/:z -v m57:/var/lib/mysql:Z "${image}"
-
-	version=$(mariadbclient --skip-column-names --loose-skip-ssl-verify-server-cert -B -u root -pbob -e "SELECT VERSION()")
-
-	docker exec "$cid" ls -la /var/lib/mysql/system_mysql_backup_unknown_version.sql.zst || die "hoping for backup file"
-
-	echo "Did the upgrade run?"
-	docker logs "$cid" 2>&1 | grep -A 15 'Starting mariadb-upgrade' || die "missing upgrade message"
-	echo
-
-	docker exec "$cid" ls -la /var/lib/mysql/
-
-	echo "Final upgrade info reflects current version?"
-	if docker exec "$cid" cat /var/lib/mysql/mysql_upgrade_info; then
-	       upgrade_file=mysql_upgrade_info
-	elif docker exec "$cid" cat /var/lib/mysql/mariadb_upgrade_info; then
-	       upgrade_file=mariadb_upgrade_info
-	else
-		die "missing {mysql,mariadb}_upgrade_info on install"
-	fi
-	echo
-
-	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
-	# note VERSION() is longer
-	[[ $version =~ ^${upgradeversion} ]] || die "upgrade version didn't match"
-
-	echo "fix version to 5.x"
-	docker exec "$cid" sed -i -e 's/[0-9]*\(.*\)/5\1/' /var/lib/mysql/$upgrade_file
-	docker exec "$cid" cat /var/lib/mysql/$upgrade_file
-	killoff
-
-	runandwait -e MARIADB_AUTO_UPGRADE=1 -v m57:/var/lib/mysql:Z "${image}"
-
-	echo "Did the upgrade run?"
-	docker logs "$cid" 2>&1 | grep -A 15 'Starting mariadb-upgrade' || die "missing upgrade from prev"
-	echo
-
-	echo "data dir"
-	docker exec "$cid" ls -la /var/lib/mysql/
-	echo
-
-	echo "Is the right backup file there?"
-	docker exec "$cid" ls -la /var/lib/mysql/system_mysql_backup_5."${upgradeversion#*.}".sql.zst || die "missing backup"
-	echo
-
-	echo "Final upgrade info reflects current version?"
-	docker exec "$cid" cat /var/lib/mysql/$upgrade_file || die "missing mysql_upgrade_info on install"
-	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
-	[[ $version =~ ^${upgradeversion} ]] || die "upgrade version didn't match current version"
-	echo
-
-	echo "Fixing back to 0 minor version"
-	docker exec "$cid" sed -i -e 's/[0-9]*-\(MariaDB\)/0-\1/' /var/lib/mysql/$upgrade_file
-	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
-	killoff
-
-	runandwait -e MARIADB_AUTO_UPGRADE=1 -v m57:/var/lib/mysql:Z "${image}"
-	docker exec "$cid" cat /var/lib/mysql/$upgrade_file
-	newupgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
-	[ "$upgradeversion" = "$newupgradeversion" ] || die "upgrade versions from mysql_upgrade_info should match"
-       	docker logs "$cid" 2>&1 | grep -C 5 'MariaDB upgrade not required' || die 'should not have upgraded'
-
-	killoff
-	docker volume rm m57
-
-	;&
-	encryption)
-
-	echo -e "Test: Startup using encryption \n"
-	runandwait -v "${dir}"/encryption_conf/:/etc/mysql/conf.d/:z -v "${dir}"/encryption:/etc/encryption/:z -v "${dir}"/initenc:/docker-entrypoint-initdb.d/:z \
-		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 -e MARIADB_DATABASE=123-databasename-456 -e MARIADB_USER=123-username-456 -e MARIADB_PASSWORD=hope "${image}"
-	mariadbclient -u root -e 'SELECT * FROM information_schema.innodb_tablespaces_encryption' || die 'Failed to start container'
-
-
-	cnt=$(mariadbclient --skip-column-names -B -u root -e 'SELECT COUNT(*) FROM information_schema.innodb_tablespaces_encryption')
-	[ "$cnt" -gt 0 ] || die 'Failed to initialize encryption on initialization'
-	killoff
-	;&
-        binlog)
-
-	echo -e "Test: Ensure time zone info isn't written to binary log\n"
-
-	runandwait \
-		-v "${dir}"/initdb.d:/docker-entrypoint-initdb.d:Z \
-		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
-		-e MARIADB_USER=bob \
-		-e MARIADB_PASSWORD=roger \
-		-e MARIADB_DATABASE=rabbit \
-		-e MARIADB_REPLICATION_USER="repluser" \
-		-e MARIADB_REPLICATION_PASSWORD="replpassword" \
-		"${image}" --log-bin --log-basename=my-mariadb
-	readarray -t vals < <(mariadbclient -u root --batch --skip-column-names -e 'show master status\G')
-	lastfile="${vals[1]}"
-	pos="${vals[2]}"
-	[[ "$lastfile" = my-mariadb-bin.00000[12] ]] || die "too many binlog files"
-	[ "$pos" -lt 500 ] || die 'binary log too big'
-	docker exec "$cid" ls -la /var/lib/mysql/my-mariadb-bin.000001
-	docker exec "$cid" sh -c '[ $(wc -c < /var/lib/mysql/my-mariadb-bin.000001 ) -gt 2500 ]' && die 'binary log 1 too big'
-	docker exec "$cid" sh -c "[ \$(wc -c < /var/lib/mysql/$lastfile ) -gt $pos ]" && die 'binary log 2 too big'
-
-	cid_primary=$cid
-	count_primary=$(mariadbclient -u bob -proger rabbit --batch --skip-column-names -e 'select sum(i) from t1')
-
-	echo -e "Test: Replica container can be initialized with same contents\n"
-
-	master_host=$cname
-	cname="mariadb-container-$RANDOM-$RANDOM"
-	cid=$(docker run \
-		-d \
-		--rm \
-		--name "$cname" \
-		-e MARIADB_MASTER_HOST="$master_host" \
-		-e MARIADB_REPLICATION_USER="repluser" \
-		-e MARIADB_REPLICATION_PASSWORD="replpassword" \
-		-e MARIADB_RANDOM_ROOT_PASSWORD=1 \
-		-e MARIADB_HEALTHCHECK_GRANTS="REPLICA MONITOR" \
-		--network=container:"$master_host" \
-		--health-cmd='healthcheck.sh --replication_io --replication_sql --replication_seconds_behind_master=0 --replication' \
-		--health-interval=3s \
-		"$image" --server-id=2 --port 3307 --require-secure-transport=1)
-
-	c="${DOCKER_LIBRARY_START_TIMEOUT:-10}"
-	until docker exec "$cid" healthcheck.sh --connect --replication_io --replication_sql --replication_seconds_behind_master=0 --replication || [ "$c" -eq 0 ]
-	do
-		sleep 1
-		c=$(( c - 1 ))
-	done
-	count_replica=$(mariadbclient_tcp -u bob -proger rabbit --batch --skip-column-names -e 'select sum(i) from t1')
-	if [ "$count_primary" != "$count_replica" ];
-	then
-		cid=$cid_primary killoff
-		die "Table contents didn't match on replica"
-	fi
-	killoff
-	cid=$master_host
-	killoff
-
-	;&
-	validate_master_env)
-
-	echo -e "Test: Expect failure for master; MARIADB_REPLICATION_USER without MARIADB_REPLICATION_PASSWORD or MARIADB_REPLICATION_PASSWORD_HASH specified\n"
-	cname="mariadb-container-replica-fail-to-start-options-$RANDOM-$RANDOM"
-	docker run  --rm  --name "$cname" \
-		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
-		-e MARIADB_REPLICATION_USER="repl" \
-		"$image" \
-		&& die "$cname should fail with incomplete options" 
-
-	;&
-	validate_replica_env)
-
-	echo -e "Test: Expect failure for replica mode without MARIADB_REPLICATION_USER specified\n"
-	cname="mariadb-container-replica-fail-to-start-options-$RANDOM-$RANDOM"
-	docker run  --rm  --name "$cname" \
-		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
-		-e MARIADB_MASTER_HOST="ok" \
-		"$image" \
-		&& die "$cname should fail with incomplete options" 
-
-	cname=
-
-	;&
-	replication)
-
-	echo -e "Test: Replica container can be initialized with environment variables when MARIADB_REPLICATION_PASSWORD is set\n"
-
-	checkReplication 'MARIADB_REPLICATION_PASSWORD'
-
-	;&
-	replication_password_hash)
-
-	echo -e "Test: Replica container can be initialized with environment variables when MARIADB_REPLICATION_PASSWORD_HASH is set\n"
-
-	checkReplication 'MARIADB_REPLICATION_PASSWORD_HASH'
-
-	;&
-	password_hash)
-
-	echo -e "Test: create user passwords using password hash\n"
-
-initdb=$(mktemp -d)
-chmod go+rx "${initdb}"
-cp -a "$dir"/initdb.d/* "${initdb}"
-sed -i -e 's/^PASS=.*/PASS=jane/' "${initdb}"/a_first.sh
-gzip "${initdb}"/*gz*
-xz "${initdb}"/*xz*
-zstd "${initdb}"/*zst*
-
-	runandwait -e MARIADB_ROOT_PASSWORD_HASH='*61584B76F6ECE8FB9A328E7CF198094B2FAC55C7' \
-		-e MARIADB_PASSWORD_HASH='*0FD9A3F0F816D076CF239580A68A1147C250EB7B' \
-		-e MARIADB_DATABASE=neptune \
-		-e MARIADB_USER=henry \
-		-v "${initdb}":/docker-entrypoint-initdb.d:Z \
-		"${image}"
-	mariadbclient -u root -pbob -e 'select current_user()'
-	mariadbclient -u root -pbob -e 'select current_user()'
-	mariadbclient -u henry -pjane neptune -e 'select current_user()'
-
-	init_sum=$(mariadbclient --skip-column-names -B -u henry -pjane -P 3306 -h 127.0.0.1  --protocol tcp neptune -e "select sum(i) from t1;")
-	[ "${init_sum}" = '1833' ] || die 'initialization order error'
-	killoff
-	rm -rf "${initdb}"
-
-	;&
-	galera_mariadbbackup)
-
-	echo -e "Test: Galera SST mechanism mariadb-backup\n"
-
-	galera_sst mariabackup
-
-	;&
-	galera_sst_rsync)
-
-	echo -e "Test: Galera SST mechanism rsync\n"
-
-	galera_sst rsync
-
-	# TODO fix - failing to do the authentication correctly of wsrep_sst_auth - Access denied on mysql usage within SST script
-	#;&
-	#galera_sst_mariadbdump)
-	#echo -e "Test: Galera SST mechanism mariadb-dump\n"
-	#
-	#galera_sst mysqldump
-
-	;&
-	backup_restore)
-
-	echo -e "Test: Backup/Restore\n"
-
-	tmpvol=v$RANDOM
-	docker volume create "$tmpvol"
-
-	runandwait -v $tmpvol:/backup \
-		--env MARIADB_ROOT_PASSWORD=soverysecret \
-		"$image"
-
-	# docker ubi volume compat
-	docker exec \
-		--user root \
-		"$cname" \
-		chmod ugo+rwt /backup
-
-	docker exec \
-		"$cname" \
-		mariadb-backup --backup --target-dir=/backup/d --user root --password=soverysecret
-
-	docker exec \
-		"$cname" \
-		mariadb-backup --prepare --target-dir=/backup/d
-
-	# purge this out, in the server we may end up saving it, but the test here
-	# is the user password is reset and file recreated on restore.
-	docker exec \
-		--workdir /backup/d \
-		"$cname" \
-		rm -f .my-healthcheck.cnf
-
-	docker exec \
-		--workdir /backup/d \
-		"$cname" \
-		tar -Jcf ../backup.tar.xz .
-
-	docker exec \
-		"$cname" \
-		rm -rf /backup/d
-
-	killoff
-
-	runandwait -v $tmpvol:/docker-entrypoint-initdb.d/:z \
-		--env MARIADB_AUTO_UPGRADE=1 \
-		"$image"
-
-	mariadbclient -u root -psoverysecret -e 'select current_user() as connected_ok'
-
-	docker exec "$cname" healthcheck.sh --connect --innodb_initialized
-	# healthcheck shouldn't return true on insufficient connection information
-
-	# Enforce fallback to tcp in healthcheck.
-	docker exec "$cname" sed -i -e 's/\(socket=\)/\1breakpath/' /var/lib/mysql/.my-healthcheck.cnf
-
-	# select @@skip-networking via tcp successful
-	docker exec "$cname" healthcheck.sh --connect
-
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` ACCOUNT LOCK'
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` ACCOUNT LOCK'
-
-	# ERROR 4151 (HY000): Access denied, this account is locked
-	docker exec "$cname" healthcheck.sh --connect
-
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` WITH MAX_QUERIES_PER_HOUR 1 ACCOUNT UNLOCK'
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` WITH MAX_QUERIES_PER_HOUR 1 ACCOUNT UNLOCK'
-
-	# ERROR 1226 (42000) at line 1: User '\''healthcheck'\'' has exceeded the '\''max_queries_per_hour'\'' resource (current value: 1)'
-	docker exec "$cname" healthcheck.sh --connect
-	docker exec "$cname" healthcheck.sh --connect
-
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` WITH MAX_QUERIES_PER_HOUR 2000 PASSWORD EXPIRE'
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` WITH MAX_QUERIES_PER_HOUR 2000 PASSWORD EXPIRE'
-	# ERROR 1820 (HY000) at line 1: You must SET PASSWORD before executing this statement
-	docker exec "$cname" healthcheck.sh --connect
-
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'set password for healthcheck@`127.0.0.1` = PASSWORD("mismatch")'
-	# shellcheck disable=SC2016
-	mariadbclient -u root -psoverysecret -e 'set password for healthcheck@`::1` = PASSWORD("mismatch")'
-
-	# ERROR 1045 (28000): Access denied
-	docker exec "$cname" healthcheck.sh --connect
-
-	# break port
-	docker exec "$cname" sed -i -e 's/\(port=\)/\14/' /var/lib/mysql/.my-healthcheck.cnf
-	docker exec "$cname" healthcheck.sh --connect || echo "ok, broken port is a connection failure"
-
-	# break config file
-	docker exec "$cname" sed -i -e 's/-client]$//' /var/lib/mysql/.my-healthcheck.cnf
-	docker exec "$cname" healthcheck.sh --connect || echo "ok, broken config file is a failure"
-
-	killoff
-
-	docker volume rm "$tmpvol"
-	tmpvol=
-
-# Insert new tests above by copying the comments below
-#	;&
-#	THE_TEST_NAME)
-#	echo -e "Test: DESCRIPTION\n"
-
-	;;
-	*)
-	echo "Test $2 not found" >&2
+if [ "$failed" -gt 0 ]; then
 	exit 1
-esac
-
-echo "Tests finished"
+fi

--- a/.test/tests/allocator.sh
+++ b/.test/tests/allocator.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Tests for memory allocators (jemalloc, tcmalloc)
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 test_jemalloc() {
 	case "$architecture" in

--- a/.test/tests/allocator.sh
+++ b/.test/tests/allocator.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Tests for memory allocators (jemalloc, tcmalloc)
+# Sourced by run.sh — do not execute directly
+
+test_jemalloc() {
+	case "$architecture" in
+		amd64)   debarch=x86_64 ;;
+		arm64)   debarch=aarch64 ;;
+		ppc64le) debarch=powerpc64le ;;
+		s390x|i386|*) debarch=$architecture ;;
+	esac
+
+	if [ -n "$debarch" ]; then
+		echo -e "Test: jemalloc preload\n"
+		runandwait -e LD_PRELOAD="/usr/lib/$debarch-linux-gnu/libjemalloc.so.1 /usr/lib/$debarch-linux-gnu/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
+		docker exec -i --user mysql "$cid" /bin/grep 'jemalloc' /proc/1/maps || die "expected to preload jemalloc"
+		killoff
+	else
+		echo -e "Test: jemalloc skipped - unknown arch '$architecture'\n"
+	fi
+}
+
+test_tcmalloc() {
+	case "$architecture" in
+		amd64)   debarch=x86_64 ;;
+		arm64)   debarch=aarch64 ;;
+		ppc64le) debarch=powerpc64le ;;
+		s390x|i386|*) debarch=$architecture ;;
+	esac
+
+	if [ -n "$debarch" ]; then
+		echo -e "Test: tcmalloc preload\n"
+		runandwait -e LD_PRELOAD="/usr/lib/$debarch-linux-gnu/libtcmalloc_minimal.so.4 /usr/lib64/libtcmalloc_minimal.so.4" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
+		docker exec -i --user mysql "$cid" /bin/grep 'tcmalloc' /proc/1/maps || die "expected to preload tcmalloc"
+		killoff
+	else
+		echo -e "Test: tcmalloc skipped - unknown arch '$architecture'\n"
+	fi
+}

--- a/.test/tests/auth.sh
+++ b/.test/tests/auth.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Tests for basic password and authentication behavior
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 # Shared between test_mysql_random_password_is_complex and test_mysql_random_password_is_different
 _last_random_pass=""
@@ -53,7 +54,7 @@ test_mysql_root_password_is_set() {
 
 	createuser=$(docker exec --user mysql -i \
 		"$cname" \
-		$mariadb \
+		"$mariadb" \
 		--silent \
 		-e "show create user")
 	# shellcheck disable=SC2016
@@ -61,7 +62,7 @@ test_mysql_root_password_is_set() {
 
 	grants="$(docker exec --user mysql -i \
 		"$cname" \
-		$mariadb \
+		"$mariadb" \
 		--silent \
 		-e show\ grants)"
 
@@ -70,7 +71,7 @@ test_mysql_root_password_is_set() {
 
 	createuser=$(docker exec --user mysql -i \
 		"$cname" \
-		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
+		"$mariadb" --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
 		--silent \
 		-e "show create user")
 	# shellcheck disable=SC2016,SC2076
@@ -80,7 +81,7 @@ test_mysql_root_password_is_set() {
 
 	grants="$(docker exec --user mysql -i \
 		"$cname" \
-		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
+		"$mariadb" --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
 		--silent \
 		-e show\ grants)"
 
@@ -102,13 +103,13 @@ test_mysql_random_password_is_complex() {
 
 	docker exec --user mysql -i \
 		"$cname" \
-		$mariadb \
+		"$mariadb" \
 		--silent \
 		-e "select 'I connect therefore I am'" || die "I'd hoped to work around MDEV-24111"
 
 	grants="$(docker exec --user mysql -i \
 		"$cname" \
-		$mariadb \
+		"$mariadb" \
 		--silent \
 		-e show\ grants)"
 

--- a/.test/tests/auth.sh
+++ b/.test/tests/auth.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Tests for basic password and authentication behavior
+# Sourced by run.sh — do not execute directly
+
+# Shared between test_mysql_random_password_is_complex and test_mysql_random_password_is_different
+_last_random_pass=""
+
+test_required_password() {
+	echo -e "Test: expect Failure - none of MYSQL_ALLOW_EMPTY_PASSWORD, MYSQL_RANDOM_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD\n"
+
+	cname="mariadb-container-fail-to-start-options-$RANDOM-$RANDOM"
+	docker run --name "$cname" --rm "$image" 2>&1 && die "$cname should fail with unspecified option"
+	return 0
+}
+
+test_mysql_allow_empty_password_is_empty() {
+	echo -e "Test: MYSQL_ALLOW_EMPTY_PASSWORD Implementation is empty value so this should fail\n"
+	docker run --rm --name "$cname" -e MYSQL_ALLOW_EMPTY_PASSWORD "$image" && die "$cname should fail with empty MYSQL_ALLOW_EMPTY_PASSWORD"
+	echo 'expected failure of empty MYSQL_ALLOW_EMPTY_PASSWORD'
+	return 0
+}
+
+test_mysql_allow_empty_password_is_clean() {
+	echo -e "Test: MYSQL_ALLOW_EMPTY_PASSWORD and defaults to clean environment, +default-storage-engine=InnoDB\n"
+
+	runandwait -e MYSQL_ALLOW_EMPTY_PASSWORD=1 "${image}" --default-storage-engine=InnoDB
+	mariadbclient -u root -e 'show databases'
+
+	othertables=$(mariadbclient -u root --skip-column-names -Be "select group_concat(SCHEMA_NAME) from information_schema.SCHEMATA where SCHEMA_NAME not in ('mysql', 'information_schema', 'performance_schema', 'sys')")
+	[ "${othertables}" != 'NULL' ] && die "unexpected table(s) $othertables"
+
+	otherusers=$(mariadbclient -u root --skip-column-names -Be "select user,host from mysql.global_priv where (user,host) not in (('root', 'localhost'), ('root', '%'), ('mariadb.sys', 'localhost'), ('healthcheck', '::1'), ('healthcheck', '127.0.0.1'), ('healthcheck', 'localhost'))")
+	[ "$otherusers" != '' ] && die "unexpected users $otherusers"
+
+	echo "Contents of /var/lib/mysql/{mysql,mariadb}_upgrade_info:"
+	docker exec "$cid" cat /var/lib/mysql/mysql_upgrade_info \
+		|| docker exec "$cid" cat /var/lib/mysql/mariadb_upgrade_info \
+		|| die "missing {mariadb,mysql_upgrade}_info on install"
+	echo
+
+	killoff
+}
+
+test_mysql_root_password_is_set() {
+	echo -e "Test: MYSQL_ROOT_PASSWORD and mysql@localhost user\n"
+
+	runandwait -e MYSQL_ROOT_PASSWORD=examplepass -e MARIADB_MYSQL_LOCALHOST_USER=1 "${image}"
+	mariadbclient -u root -pexamplepass -e 'select current_user()'
+	mariadbclient -u root -pwrongpass -e 'select current_user()' || echo 'expected failure'
+
+	otherusers=$(mariadbclient -u root -pexamplepass --skip-column-names -Be "select user,host from mysql.global_priv where (user,host) not in (('root', 'localhost'), ('root', '%'), ('mariadb.sys', 'localhost'), ('mysql','localhost'), ('healthcheck', '::1'), ('healthcheck', '127.0.0.1'), ('healthcheck', 'localhost'))")
+	[ "$otherusers" != '' ] && die "unexpected users $otherusers"
+
+	createuser=$(docker exec --user mysql -i \
+		"$cname" \
+		$mariadb \
+		--silent \
+		-e "show create user")
+	# shellcheck disable=SC2016
+	[ "${createuser//\'/\`}" == 'CREATE USER `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "mysql@localhost wasn't created how I was expected"
+
+	grants="$(docker exec --user mysql -i \
+		"$cname" \
+		$mariadb \
+		--silent \
+		-e show\ grants)"
+
+	# shellcheck disable=SC2016
+	[ "${grants//\'/\`}" == 'GRANT USAGE ON *.* TO `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "mysql@localhost wasn't granted what I was expected"
+
+	createuser=$(docker exec --user mysql -i \
+		"$cname" \
+		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
+		--silent \
+		-e "show create user")
+	# shellcheck disable=SC2016,SC2076
+	[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`localhost` IDENTIFIED' ]] || \
+		[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`::1` IDENTIFIED' ]] || \
+		[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`127.0.0.1` IDENTIFIED' ]] || die "healthcheck wasn't created how I was expected"
+
+	grants="$(docker exec --user mysql -i \
+		"$cname" \
+		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
+		--silent \
+		-e show\ grants)"
+
+	[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`localhost\` ]] || \
+		[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`::1\` ]] || \
+		[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`127.0.0.1\` ]] || die "healthcheck wasn't granted what I was expected"
+	killoff
+}
+
+test_mysql_random_password_is_complex() {
+	echo -e "Test: MYSQL_RANDOM_ROOT_PASSWORD, needs to satisfy minimum complexity of simple-password-check plugin and old-mode=''\n"
+
+	runandwait -e MYSQL_RANDOM_ROOT_PASSWORD=1 -e MARIADB_MYSQL_LOCALHOST_USER=1 -e MARIADB_MYSQL_LOCALHOST_GRANTS="RELOAD, PROCESS, LOCK TABLES" \
+		"${image}" --plugin-load-add=simple_password_check --old-mode=""
+	_last_random_pass=$(docker logs "$cid" | grep 'GENERATED ROOT PASSWORD' 2>&1)
+	# trim up until password
+	_last_random_pass=${_last_random_pass#*GENERATED ROOT PASSWORD: }
+	mariadbclient -u root -p"${_last_random_pass}" -e 'select current_user()'
+
+	docker exec --user mysql -i \
+		"$cname" \
+		$mariadb \
+		--silent \
+		-e "select 'I connect therefore I am'" || die "I'd hoped to work around MDEV-24111"
+
+	grants="$(docker exec --user mysql -i \
+		"$cname" \
+		$mariadb \
+		--silent \
+		-e show\ grants)"
+
+	# shellcheck disable=SC2016
+	[ "${grants//\'/\`}" == 'GRANT RELOAD, PROCESS, LOCK TABLES ON *.* TO `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "I wasn't granted what I was expected"
+
+	killoff
+}
+
+test_mysql_random_password_is_different() {
+	echo -e "Test: second instance of MYSQL_RANDOM_ROOT_PASSWORD has a different password (and mysql@localhost can be created)\n"
+
+	runandwait -e MYSQL_RANDOM_ROOT_PASSWORD=1 -e MARIADB_MYSQL_LOCALHOST_USER=1 "${image}" --plugin-load-add=simple_password_check
+	newpass=$(docker logs "$cid" | grep 'GENERATED ROOT PASSWORD' 2>&1)
+	# trim up until password
+	newpass=${newpass#*GENERATED ROOT PASSWORD: }
+	mariadbclient -u root -p"${newpass}" -e 'select current_user()'
+	killoff
+
+	[ "$_last_random_pass" = "$newpass" ] && die "highly improbable - two consecutive passwords are the same"
+	return 0
+}
+
+test_mysql_root_host_sets_host() {
+	echo -e "Test: MYSQL_ROOT_HOST\n"
+
+	runandwait -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_ROOT_HOST=apple "${image}"
+	ru=$(mariadbclient --skip-column-names -B -u root -e 'select user,host from mysql.global_priv where host="apple"')
+	[ "${ru}" = '' ] && die 'root@apple not created'
+	killoff
+}
+
+test_mysql_root_host_localhost() {
+	echo -e "Test: MYSQL_ROOT_HOST=localhost\n"
+
+	runandwait -e MARIADB_ROOT_PASSWORD=bob -e MYSQL_ROOT_HOST=localhost "${image}"
+	ru=$(mariadbclient --skip-column-names -B -u root -pbob -e 'select user,host from mysql.global_priv where user="root" and host="localhost"')
+	[ "${ru}" = '' ] && die 'root@localhost not created'
+	killoff
+}
+
+test_complex_passwords() {
+	echo -e "Test: complex passwords\n"
+
+	runandwait -e MYSQL_USER=bob -e MYSQL_PASSWORD=$'\n $\' \n' -e MYSQL_ROOT_PASSWORD=$'\n\'\\aa-\x09-zz"_%\n' \
+		-e MARIADB_REPLICATION_USER="foo" \
+		-e MARIADB_REPLICATION_PASSWORD=$'\n\'\\aa-\x09-zz"_%\n' \
+		"${image}"
+	mariadbclient --skip-column-names -B -u root -p$'\n\'\\aa-\x09-zz"_%\n' -e 'select 1'
+	mariadbclient --skip-column-names -B -u foo -p$'\n\'\\aa-\x09-zz"_%\n' -e 'select 1'
+	mariadbclient --skip-column-names -B -u bob -p$'\n $\' \n' -e 'select 1'
+	killoff
+}
+
+test_password_hash() {
+	echo -e "Test: create user passwords using password hash\n"
+
+	initdb=$(mktemp -d)
+	chmod go+rx "${initdb}"
+	cp -a "$dir"/initdb.d/* "${initdb}"
+	chmod -R go+rX "${initdb}"
+	sed -i -e 's/^PASS=.*/PASS=jane/' "${initdb}"/a_first.sh
+	gzip "${initdb}"/*gz*
+	xz "${initdb}"/*xz*
+	zstd "${initdb}"/*zst*
+
+	runandwait -e MARIADB_ROOT_PASSWORD_HASH='*61584B76F6ECE8FB9A328E7CF198094B2FAC55C7' \
+		-e MARIADB_PASSWORD_HASH='*0FD9A3F0F816D076CF239580A68A1147C250EB7B' \
+		-e MARIADB_DATABASE=neptune \
+		-e MARIADB_USER=henry \
+		-v "${initdb}":/docker-entrypoint-initdb.d:Z \
+		"${image}"
+	mariadbclient -u root -pbob -e 'select current_user()'
+	mariadbclient -u root -pbob -e 'select current_user()'
+	mariadbclient -u henry -pjane neptune -e 'select current_user()'
+
+	init_sum=$(mariadbclient --skip-column-names -B -u henry -pjane -P 3306 -h 127.0.0.1 --protocol tcp neptune -e "select sum(i) from t1;")
+	[ "${init_sum}" = '1833' ] || die 'initialization order error'
+	killoff
+	rm -rf "${initdb}"
+}

--- a/.test/tests/init.sh
+++ b/.test/tests/init.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Tests for initialization, timezone, secrets, and configuration
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 test_mysql_initdb_skip_tzinfo_empty() {
 	echo -e "Test: MYSQL_INITDB_SKIP_TZINFO='' should still load timezones\n"
@@ -36,7 +37,7 @@ test_secrets_via_file() {
 	tmpvol=v$RANDOM
 	docker volume create "$tmpvol"
 	# any container will work with tar in it, we may well use the image we have
-	(cd "$secretdir" ; tar -cf - .) | docker run --rm --volume "$tmpvol":/v --user root -i "${image}" tar -xf - -C /v
+	(cd "$secretdir" || exit ; tar -cf - .) | docker run --rm --volume "$tmpvol":/v --user root -i "${image}" tar -xf - -C /v
 	rm -rf "${secretdir}"
 
 	runandwait \

--- a/.test/tests/init.sh
+++ b/.test/tests/init.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Tests for initialization, timezone, secrets, and configuration
+# Sourced by run.sh — do not execute directly
+
+test_mysql_initdb_skip_tzinfo_empty() {
+	echo -e "Test: MYSQL_INITDB_SKIP_TZINFO='' should still load timezones\n"
+
+	# ONLY_FULL_GROUP_BY - test for MDEV-29347
+	runandwait -e MYSQL_INITDB_SKIP_TZINFO= -e MYSQL_ALLOW_EMPTY_PASSWORD=1 "${image}" --default-time-zone=Europe/Berlin --sql-mode=ONLY_FULL_GROUP_BY
+	tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
+	[ "${tzcount}" = '0' ] && die "should exist timezones"
+	[ "$(mariadbclient --skip-column-names -B -u root -e 'SELECT @@time_zone')" != "Europe/Berlin" ] && die "Didn't set timezone to Berlin"
+	killoff
+}
+
+test_mysql_initdb_skip_tzinfo_no_empty() {
+	echo -e "Test: MYSQL_INITDB_SKIP_TZINFO=1 should not load timezones\n"
+
+	runandwait -e MYSQL_INITDB_SKIP_TZINFO=1 -e MYSQL_ALLOW_EMPTY_PASSWORD=1 "${image}"
+	tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
+	[ "${tzcount}" = '0' ] || die "timezones shouldn't be loaded - found ${tzcount}"
+	killoff
+}
+
+test_secrets_via_file() {
+	echo -e "Test: Secrets _FILE vars should be same as env directly\n"
+
+	secretdir=$(mktemp -d)
+	chmod go+rx "${secretdir}"
+	echo bob > "$secretdir"/pass
+	echo pluto > "$secretdir"/host
+	echo titan > "$secretdir"/db
+	echo ron > "$secretdir"/u
+	echo '*D87991C62A9CAEDC4AE0F608F19173AC7E614952' > "$secretdir"/p
+
+	tmpvol=v$RANDOM
+	docker volume create "$tmpvol"
+	# any container will work with tar in it, we may well use the image we have
+	(cd "$secretdir" ; tar -cf - .) | docker run --rm --volume "$tmpvol":/v --user root -i "${image}" tar -xf - -C /v
+	rm -rf "${secretdir}"
+
+	runandwait \
+		-v "$tmpvol":/run/secrets \
+		-e MYSQL_ROOT_PASSWORD_FILE=/run/secrets/pass \
+		-e MYSQL_ROOT_HOST_FILE=/run/secrets/host \
+		-e MYSQL_DATABASE_FILE=/run/secrets/db \
+		-e MYSQL_USER_FILE=/run/secrets/u \
+		-e MARIADB_PASSWORD_HASH_FILE=/run/secrets/p \
+		"${image}"
+
+	host=$(mariadbclient --skip-column-names -B -u root -pbob -e 'select host from mysql.global_priv where user="root" and host="pluto"' titan)
+	[ "${host}" != 'pluto' ] && die 'root@pluto not created'
+	creation=$(mariadbclient --skip-column-names -B -u ron -pscappers -P 3306 --protocol tcp titan -e "CREATE TABLE landing(i INT)")
+	[ "${creation}" = '' ] || die 'creation error'
+	killoff
+	docker volume rm "$tmpvol"
+	tmpvol=
+}
+
+test_docker_entrypoint_initdb() {
+	echo -e "Test: docker-entrypoint-initdb.d Initialization order is correct and processed\n"
+
+	initdb=$(prepare_initdb)
+
+	runandwait \
+		-v "${initdb}":/docker-entrypoint-initdb.d:Z \
+		-e MYSQL_ROOT_PASSWORD=ssh \
+		-e MYSQL_DATABASE=titan \
+		-e MYSQL_USER=ron \
+		-e MYSQL_PASSWORD=scappers \
+		"${image}"
+
+	init_sum=$(mariadbclient --skip-column-names -B -u ron -pscappers -P 3306 -h 127.0.0.1 --protocol tcp titan -e "select sum(i) from t1;")
+	[ "${init_sum}" = '1833' ] || die 'initialization order error'
+	killoff
+	rm -rf "${initdb}"
+}
+
+test_mariadb_initdb_skip_tzinfo_empty() {
+	echo -e "Test: MARIADB_INITDB_SKIP_TZINFO=''\n"
+
+	runandwait -e MARIADB_INITDB_SKIP_TZINFO= -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
+	tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
+	[ "${tzcount}" = '0' ] && die "should exist time zones"
+
+	# note uses previous instance
+	echo -e "Test: default configuration items are present\n"
+	arg_expected=0
+	docker exec -i "$cid" my_print_defaults --mysqld |
+		{
+		while read -r line; do
+			case $line in
+			--host-cache-size=0|--skip-name-resolve)
+				echo "$line" found
+				(( arg_expected++ )) || : ;;
+			esac
+		done
+		[ "$arg_expected" -eq 2 ] || die "expected both host-cache-size=0 and skip-name-resolve"
+	}
+	killoff
+}
+
+test_mariadb_initdb_skip_tzinfo_not_empty() {
+	echo -e "Test: MARIADB_INITDB_SKIP_TZINFO=1\n"
+
+	runandwait -e MARIADB_INITDB_SKIP_TZINFO=1 -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
+	tzcount=$(mariadbclient --skip-column-names -B -u root -e "SELECT COUNT(*) FROM mysql.time_zone")
+	[ "${tzcount}" = '0' ] || die "timezones shouldn't be loaded - found ${tzcount}"
+	killoff
+}
+
+test_encryption() {
+	echo -e "Test: Startup using encryption\n"
+
+	runandwait -v "${dir}"/encryption_conf/:/etc/mysql/conf.d/:z -v "${dir}"/encryption:/etc/encryption/:z -v "${dir}"/initenc:/docker-entrypoint-initdb.d/:z \
+		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 -e MARIADB_DATABASE=123-databasename-456 -e MARIADB_USER=123-username-456 -e MARIADB_PASSWORD=hope "${image}"
+	mariadbclient -u root -e 'SELECT * FROM information_schema.innodb_tablespaces_encryption' || die 'Failed to start container'
+
+	cnt=$(mariadbclient --skip-column-names -B -u root -e 'SELECT COUNT(*) FROM information_schema.innodb_tablespaces_encryption')
+	[ "$cnt" -gt 0 ] || die 'Failed to initialize encryption on initialization'
+	killoff
+}

--- a/.test/tests/mariadb_env.sh
+++ b/.test/tests/mariadb_env.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Tests for MariaDB-prefixed environment variables
+# Sourced by run.sh — do not execute directly
+
+# Shared between test_mariadb_root_password_is_complex and test_mariadb_root_password_is_different
+_last_mariadb_random_pass=""
+
+test_prefer_mariadb_names() {
+	echo -e "Test: when provided with MYSQL_ and MARIADB_ names, Prefer MariaDB names\n"
+
+	runandwait -e MARIADB_ROOT_PASSWORD=examplepass -e MYSQL_ROOT_PASSWORD=mysqlexamplepass "${image}"
+	mariadbclient -u root -pexamplepass -e 'select current_user()'
+	mariadbclient -u root -pwrongpass -e 'select current_user()' || echo 'expected failure of wrong password'
+	killoff
+}
+
+test_mariadb_allow_empty_root_password_empty() {
+	echo -e "Test: MARIADB_ALLOW_EMPTY_ROOT_PASSWORD Implementation is empty value so this should fail\n"
+
+	docker run --rm --name "$cname" -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD "$image" || echo 'expected failure MARIADB_ALLOW_EMPTY_ROOT_PASSWORD is empty'
+	return 0
+}
+
+test_mariadb_allow_empty_root_password_not_empty() {
+	echo -e "Test: MARIADB_ALLOW_EMPTY_ROOT_PASSWORD\n"
+
+	# +Defaults to clean environment
+	runandwait -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 "${image}"
+	mariadbclient -u root -e 'show databases'
+
+	othertables=$(mariadbclient -u root --skip-column-names -Be "select group_concat(SCHEMA_NAME) from information_schema.SCHEMATA where SCHEMA_NAME not in ('mysql', 'information_schema', 'performance_schema', 'sys')")
+	[ "${othertables}" != 'NULL' ] && die "unexpected table(s) $othertables"
+
+	otherusers=$(mariadbclient -u root --skip-column-names -Be "select user,host from mysql.global_priv where (user,host) not in (('root', 'localhost'), ('root', '%'), ('mariadb.sys', 'localhost'), ('mysql','localhost'), ('healthcheck', '::1'), ('healthcheck', '127.0.0.1'), ('healthcheck', 'localhost'))")
+	[ "$otherusers" != '' ] && die "unexpected users $otherusers"
+	killoff
+}
+
+test_mariadb_root_password_is_set() {
+	echo -e "Test: MARIADB_ROOT_PASSWORD\n"
+
+	runandwait -e MARIADB_ROOT_PASSWORD=examplepass "${image}"
+	mariadbclient -u root -pexamplepass -e 'select current_user()'
+	mariadbclient -u root -pwrongpass -e 'select current_user()' || echo 'expected failure'
+	killoff
+}
+
+test_mariadb_root_password_is_complex() {
+	echo -e "Test: MARIADB_RANDOM_ROOT_PASSWORD, needs to satisfy minimum complexity of simple-password-check plugin\n"
+
+	runandwait -e MARIADB_RANDOM_ROOT_PASSWORD=1 "${image}" --plugin-load-add=simple_password_check
+	_last_mariadb_random_pass=$(docker logs "$cid" 2>&1 | grep 'GENERATED ROOT PASSWORD')
+	# trim up until password
+	_last_mariadb_random_pass=${_last_mariadb_random_pass#*GENERATED ROOT PASSWORD: }
+	mariadbclient -u root -p"${_last_mariadb_random_pass}" -e 'select current_user()'
+	killoff
+}
+
+test_mariadb_root_password_is_different() {
+	echo -e "Test: second instance of MARIADB_RANDOM_ROOT_PASSWORD has a different password\n"
+
+	runandwait -e MARIADB_RANDOM_ROOT_PASSWORD=1 "${image}" --plugin-load-add=simple_password_check
+	newpass=$(docker logs "$cid" 2>&1 | grep 'GENERATED ROOT PASSWORD')
+	# trim up until password
+	newpass=${newpass#*GENERATED ROOT PASSWORD: }
+	mariadbclient -u root -p"${newpass}" -e 'select current_user()'
+	killoff
+
+	[ "$_last_mariadb_random_pass" = "$newpass" ] && die "highly improbable - two consecutive random passwords are the same"
+	return 0
+}
+
+test_mariadb_root_host_sets_host() {
+	echo -e "Test: MARIADB_ROOT_HOST\n"
+
+	runandwait -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 -e MARIADB_ROOT_HOST=apple "${image}"
+	ru=$(mariadbclient --skip-column-names -B -u root -e 'select user,host from mysql.global_priv where host="apple"')
+	[ "${ru}" = '' ] && die 'root@apple not created'
+	killoff
+}
+
+test_mariadb_user_host() {
+	echo -e "Test: MARIADB_USER_HOST makes user host configurable at init\n"
+
+	runandwait -e MARIADB_ROOT_PASSWORD=secr3t \
+		-e MARIADB_USER=testuser \
+		-e MARIADB_PASSWORD=testpass \
+		-e MARIADB_DATABASE=testdb \
+		-e MARIADB_USER_HOST=192.168.1.0/255.255.255.0 \
+		"${image}"
+
+	uh=$(mariadbclient --skip-column-names -B -u root -p"secr3t" -e "select user,host from mysql.global_priv where user='testuser'")
+	[ "${uh}" = '' ] && die 'testuser with custom host not created'
+	host=$(mariadbclient --skip-column-names -B -u root -p"secr3t" -e "select host from mysql.global_priv where user='testuser'")
+	[ "${host}" = '192.168.1.0/255.255.255.0' ] || die "expected host '192.168.1.0/255.255.255.0' but got '${host}'"
+	killoff
+
+	echo -e "Test: MARIADB_USER_HOST defaults to '%' when not specified\n"
+
+	runandwait -e MARIADB_ROOT_PASSWORD=secr3t \
+		-e MARIADB_USER=testuser \
+		-e MARIADB_PASSWORD=testpass \
+		-e MARIADB_DATABASE=testdb \
+		"${image}"
+
+	host=$(mariadbclient --skip-column-names -B -u root -p"secr3t" -e "select host from mysql.global_priv where user='testuser'")
+	[ "${host}" = '%' ] || die "expected default host '%' but got '${host}'"
+	killoff
+}

--- a/.test/tests/mariadb_env.sh
+++ b/.test/tests/mariadb_env.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Tests for MariaDB-prefixed environment variables
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 # Shared between test_mariadb_root_password_is_complex and test_mariadb_root_password_is_different
 _last_mariadb_random_pass=""

--- a/.test/tests/replication.sh
+++ b/.test/tests/replication.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Tests for replication, binlog, and Galera
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 test_binlog() {
 	echo -e "Test: Ensure time zone info isn't written to binary log\n"

--- a/.test/tests/replication.sh
+++ b/.test/tests/replication.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Tests for replication, binlog, and Galera
+# Sourced by run.sh — do not execute directly
+
+test_binlog() {
+	echo -e "Test: Ensure time zone info isn't written to binary log\n"
+
+	runandwait \
+		-v "${dir}"/initdb.d:/docker-entrypoint-initdb.d:Z \
+		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
+		-e MARIADB_USER=bob \
+		-e MARIADB_PASSWORD=roger \
+		-e MARIADB_DATABASE=rabbit \
+		-e MARIADB_REPLICATION_USER="repluser" \
+		-e MARIADB_REPLICATION_PASSWORD="replpassword" \
+		"${image}" --log-bin --log-basename=my-mariadb
+	readarray -t vals < <(mariadbclient -u root --batch --skip-column-names -e 'show master status\G')
+	lastfile="${vals[1]}"
+	pos="${vals[2]}"
+	[[ "$lastfile" = my-mariadb-bin.00000[12] ]] || die "too many binlog files"
+	[ "$pos" -lt 500 ] || die 'binary log too big'
+	docker exec "$cid" ls -la /var/lib/mysql/my-mariadb-bin.000001
+	docker exec "$cid" sh -c '[ $(wc -c < /var/lib/mysql/my-mariadb-bin.000001 ) -gt 2500 ]' && die 'binary log 1 too big'
+	docker exec "$cid" sh -c "[ \$(wc -c < /var/lib/mysql/$lastfile ) -gt $pos ]" && die 'binary log 2 too big'
+
+	cid_primary=$cid
+
+	count_primary=$(mariadbclient -u bob -proger rabbit --batch --skip-column-names -e 'select sum(i) from t1')
+
+	echo -e "Test: Replica container can be initialized with same contents\n"
+
+	master_host=$cname
+	cname="mariadb-container-$RANDOM-$RANDOM"
+	cid=$(docker run \
+		-d \
+		--rm \
+		--name "$cname" \
+		-e MARIADB_MASTER_HOST="$master_host" \
+		-e MARIADB_REPLICATION_USER="repluser" \
+		-e MARIADB_REPLICATION_PASSWORD="replpassword" \
+		-e MARIADB_RANDOM_ROOT_PASSWORD=1 \
+		-e MARIADB_HEALTHCHECK_GRANTS="REPLICA MONITOR" \
+		--network=container:"$master_host" \
+		--health-cmd='healthcheck.sh --replication_io --replication_sql --replication_seconds_behind_master=0 --replication' \
+		--health-interval=3s \
+		"$image" --server-id=2 --port 3307 --require-secure-transport=1)
+
+	c="${DOCKER_LIBRARY_START_TIMEOUT:-10}"
+	until docker exec "$cid" healthcheck.sh --connect --replication_io --replication_sql --replication_seconds_behind_master=0 --replication || [ "$c" -eq 0 ]; do
+		sleep 1
+		c=$(( c - 1 ))
+	done
+	count_replica=$(mariadbclient_tcp -u bob -proger rabbit --batch --skip-column-names -e 'select sum(i) from t1')
+	if [ "$count_primary" != "$count_replica" ]; then
+		cid=$cid_primary killoff
+		die "Table contents didn't match on replica"
+	fi
+	killoff
+	cid=$master_host
+	killoff
+}
+
+test_validate_master_env() {
+	echo -e "Test: Expect failure for master; MARIADB_REPLICATION_USER without MARIADB_REPLICATION_PASSWORD or MARIADB_REPLICATION_PASSWORD_HASH specified\n"
+
+	cname="mariadb-container-replica-fail-to-start-options-$RANDOM-$RANDOM"
+	docker run --rm --name "$cname" \
+		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
+		-e MARIADB_REPLICATION_USER="repl" \
+		"$image" \
+		&& die "$cname should fail with incomplete options"
+	return 0
+}
+
+test_validate_replica_env() {
+	echo -e "Test: Expect failure for replica mode without MARIADB_REPLICATION_USER specified\n"
+
+	cname="mariadb-container-replica-fail-to-start-options-$RANDOM-$RANDOM"
+	docker run --rm --name "$cname" \
+		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
+		-e MARIADB_MASTER_HOST="ok" \
+		"$image" \
+		&& die "$cname should fail with incomplete options"
+	cname=
+	return 0
+}
+
+test_replication() {
+	echo -e "Test: Replica container can be initialized with environment variables when MARIADB_REPLICATION_PASSWORD is set\n"
+
+	checkReplication 'MARIADB_REPLICATION_PASSWORD'
+}
+
+test_replication_password_hash() {
+	echo -e "Test: Replica container can be initialized with environment variables when MARIADB_REPLICATION_PASSWORD_HASH is set\n"
+
+	checkReplication 'MARIADB_REPLICATION_PASSWORD_HASH'
+}
+
+test_galera_mariadbbackup() {
+	echo -e "Test: Galera SST mechanism mariadb-backup\n"
+
+	galera_sst mariabackup
+}
+
+test_galera_sst_rsync() {
+	echo -e "Test: Galera SST mechanism rsync\n"
+
+	galera_sst rsync
+}

--- a/.test/tests/upgrade.sh
+++ b/.test/tests/upgrade.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Tests for upgrade and backup/restore flows
+# Sourced by run.sh — do not execute directly
+
+test_mariadbupgrade() {
+	docker volume rm m57 || echo "m57 already cleaned"
+	docker volume create m57
+	docker pull docker.io/library/mysql:5.7
+	mariadb=mysql runandwait -v m57:/var/lib/mysql:Z -e MYSQL_INITDB_SKIP_TZINFO=1 -e MYSQL_ROOT_PASSWORD=bob docker.io/library/mysql:5.7
+	# clean shutdown required
+	docker exec "$cid" mysql -u root -pbob -e "set global innodb_fast_shutdown=0;SHUTDOWN"
+	while docker exec "$cid" ls -lad /proc/1; do
+		sleep 1
+	done
+
+	# tls test to ensure that #592 is resolved
+	DOCKER_LIBRARY_START_TIMEOUT=$(( ${DOCKER_LIBRARY_START_TIMEOUT:-10} * 7 )) runandwait -e MARIADB_AUTO_UPGRADE=1 -v "${dir}"/tls:/etc/mysql/conf.d/:z -v m57:/var/lib/mysql:Z "${image}"
+
+	version=$(mariadbclient --skip-column-names --loose-skip-ssl-verify-server-cert -B -u root -pbob -e "SELECT VERSION()")
+
+	docker exec "$cid" ls -la /var/lib/mysql/system_mysql_backup_unknown_version.sql.zst || die "hoping for backup file"
+
+	echo "Did the upgrade run?"
+	docker logs "$cid" 2>&1 | grep -A 15 'Starting mariadb-upgrade' || die "missing upgrade message"
+	echo
+
+	docker exec "$cid" ls -la /var/lib/mysql/
+
+	echo "Final upgrade info reflects current version?"
+	if docker exec "$cid" cat /var/lib/mysql/mysql_upgrade_info; then
+		upgrade_file=mysql_upgrade_info
+	elif docker exec "$cid" cat /var/lib/mysql/mariadb_upgrade_info; then
+		upgrade_file=mariadb_upgrade_info
+	else
+		die "missing {mysql,mariadb}_upgrade_info on install"
+	fi
+	echo
+
+	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	# note VERSION() is longer
+	[[ $version =~ ^${upgradeversion} ]] || die "upgrade version didn't match"
+
+	echo "fix version to 5.x"
+	docker exec "$cid" sed -i -e 's/[0-9]*\(.*\)/5\1/' /var/lib/mysql/$upgrade_file
+	docker exec "$cid" cat /var/lib/mysql/$upgrade_file
+	killoff
+
+	runandwait -e MARIADB_AUTO_UPGRADE=1 -v m57:/var/lib/mysql:Z "${image}"
+
+	echo "Did the upgrade run?"
+	docker logs "$cid" 2>&1 | grep -A 15 'Starting mariadb-upgrade' || die "missing upgrade from prev"
+	echo
+
+	echo "data dir"
+	docker exec "$cid" ls -la /var/lib/mysql/
+	echo
+
+	echo "Is the right backup file there?"
+	docker exec "$cid" ls -la /var/lib/mysql/system_mysql_backup_5."${upgradeversion#*.}".sql.zst || die "missing backup"
+	echo
+
+	echo "Final upgrade info reflects current version?"
+	docker exec "$cid" cat /var/lib/mysql/$upgrade_file || die "missing mysql_upgrade_info on install"
+	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	[[ $version =~ ^${upgradeversion} ]] || die "upgrade version didn't match current version"
+	echo
+
+	echo "Fixing back to 0 minor version"
+	docker exec "$cid" sed -i -e 's/[0-9]*-\(MariaDB\)/0-\1/' /var/lib/mysql/$upgrade_file
+	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	killoff
+
+	runandwait -e MARIADB_AUTO_UPGRADE=1 -v m57:/var/lib/mysql:Z "${image}"
+	docker exec "$cid" cat /var/lib/mysql/$upgrade_file
+	newupgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	[ "$upgradeversion" = "$newupgradeversion" ] || die "upgrade versions from mysql_upgrade_info should match"
+	docker logs "$cid" 2>&1 | grep -C 5 'MariaDB upgrade not required' || die 'should not have upgraded'
+
+	killoff
+	docker volume rm m57
+}
+
+test_backup_restore() {
+	echo -e "Test: Backup/Restore\n"
+
+	tmpvol=v$RANDOM
+	docker volume create "$tmpvol"
+
+	runandwait -v $tmpvol:/backup \
+		--env MARIADB_ROOT_PASSWORD=soverysecret \
+		"$image"
+
+	# docker ubi volume compat
+	docker exec \
+		--user root \
+		"$cname" \
+		chmod ugo+rwt /backup
+
+	docker exec \
+		"$cname" \
+		mariadb-backup --backup --target-dir=/backup/d --user root --password=soverysecret
+
+	docker exec \
+		"$cname" \
+		mariadb-backup --prepare --target-dir=/backup/d
+
+	# purge this out, in the server we may end up saving it, but the test here
+	# is the user password is reset and file recreated on restore.
+	docker exec \
+		--workdir /backup/d \
+		"$cname" \
+		rm -f .my-healthcheck.cnf
+
+	docker exec \
+		--workdir /backup/d \
+		"$cname" \
+		tar -Jcf ../backup.tar.xz .
+
+	docker exec \
+		"$cname" \
+		rm -rf /backup/d
+
+	killoff
+
+	runandwait -v $tmpvol:/docker-entrypoint-initdb.d/:z \
+		--env MARIADB_AUTO_UPGRADE=1 \
+		"$image"
+
+	mariadbclient -u root -psoverysecret -e 'select current_user() as connected_ok'
+
+	docker exec "$cname" healthcheck.sh --connect --innodb_initialized
+	# healthcheck shouldn't return true on insufficient connection information
+
+	# Enforce fallback to tcp in healthcheck.
+	docker exec "$cname" sed -i -e 's/\(socket=\)/\1breakpath/' /var/lib/mysql/.my-healthcheck.cnf
+
+	# select @@skip-networking via tcp successful
+	docker exec "$cname" healthcheck.sh --connect
+
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` ACCOUNT LOCK'
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` ACCOUNT LOCK'
+
+	# ERROR 4151 (HY000): Access denied, this account is locked
+	docker exec "$cname" healthcheck.sh --connect
+
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` WITH MAX_QUERIES_PER_HOUR 1 ACCOUNT UNLOCK'
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` WITH MAX_QUERIES_PER_HOUR 1 ACCOUNT UNLOCK'
+
+	# ERROR 1226 (42000) at line 1: User 'healthcheck' has exceeded the 'max_queries_per_hour' resource (current value: 1)'
+	docker exec "$cname" healthcheck.sh --connect
+	docker exec "$cname" healthcheck.sh --connect
+
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` WITH MAX_QUERIES_PER_HOUR 2000 PASSWORD EXPIRE'
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` WITH MAX_QUERIES_PER_HOUR 2000 PASSWORD EXPIRE'
+	# ERROR 1820 (HY000) at line 1: You must SET PASSWORD before executing this statement
+	docker exec "$cname" healthcheck.sh --connect
+
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'set password for healthcheck@`127.0.0.1` = PASSWORD("mismatch")'
+	# shellcheck disable=SC2016
+	mariadbclient -u root -psoverysecret -e 'set password for healthcheck@`::1` = PASSWORD("mismatch")'
+
+	# ERROR 1045 (28000): Access denied
+	docker exec "$cname" healthcheck.sh --connect
+
+	# break port
+	docker exec "$cname" sed -i -e 's/\(port=\)/\14/' /var/lib/mysql/.my-healthcheck.cnf
+	docker exec "$cname" healthcheck.sh --connect || echo "ok, broken port is a connection failure"
+
+	# break config file
+	docker exec "$cname" sed -i -e 's/-client]$//' /var/lib/mysql/.my-healthcheck.cnf
+	docker exec "$cname" healthcheck.sh --connect || echo "ok, broken config file is a failure"
+
+	killoff
+
+	docker volume rm "$tmpvol"
+	tmpvol=
+}

--- a/.test/tests/upgrade.sh
+++ b/.test/tests/upgrade.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Tests for upgrade and backup/restore flows
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 test_mariadbupgrade() {
 	docker volume rm m57 || echo "m57 already cleaned"
@@ -36,13 +37,13 @@ test_mariadbupgrade() {
 	fi
 	echo
 
-	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/"$upgrade_file")
 	# note VERSION() is longer
 	[[ $version =~ ^${upgradeversion} ]] || die "upgrade version didn't match"
 
 	echo "fix version to 5.x"
-	docker exec "$cid" sed -i -e 's/[0-9]*\(.*\)/5\1/' /var/lib/mysql/$upgrade_file
-	docker exec "$cid" cat /var/lib/mysql/$upgrade_file
+	docker exec "$cid" sed -i -e 's/[0-9]*\(.*\)/5\1/' /var/lib/mysql/"$upgrade_file"
+	docker exec "$cid" cat /var/lib/mysql/"$upgrade_file"
 	killoff
 
 	runandwait -e MARIADB_AUTO_UPGRADE=1 -v m57:/var/lib/mysql:Z "${image}"
@@ -60,19 +61,19 @@ test_mariadbupgrade() {
 	echo
 
 	echo "Final upgrade info reflects current version?"
-	docker exec "$cid" cat /var/lib/mysql/$upgrade_file || die "missing mysql_upgrade_info on install"
-	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	docker exec "$cid" cat /var/lib/mysql/"$upgrade_file" || die "missing mysql_upgrade_info on install"
+	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/"$upgrade_file")
 	[[ $version =~ ^${upgradeversion} ]] || die "upgrade version didn't match current version"
 	echo
 
 	echo "Fixing back to 0 minor version"
-	docker exec "$cid" sed -i -e 's/[0-9]*-\(MariaDB\)/0-\1/' /var/lib/mysql/$upgrade_file
-	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	docker exec "$cid" sed -i -e 's/[0-9]*-\(MariaDB\)/0-\1/' /var/lib/mysql/"$upgrade_file"
+	upgradeversion=$(docker exec "$cid" cat /var/lib/mysql/"$upgrade_file")
 	killoff
 
 	runandwait -e MARIADB_AUTO_UPGRADE=1 -v m57:/var/lib/mysql:Z "${image}"
-	docker exec "$cid" cat /var/lib/mysql/$upgrade_file
-	newupgradeversion=$(docker exec "$cid" cat /var/lib/mysql/$upgrade_file)
+	docker exec "$cid" cat /var/lib/mysql/"$upgrade_file"
+	newupgradeversion=$(docker exec "$cid" cat /var/lib/mysql/"$upgrade_file")
 	[ "$upgradeversion" = "$newupgradeversion" ] || die "upgrade versions from mysql_upgrade_info should match"
 	docker logs "$cid" 2>&1 | grep -C 5 'MariaDB upgrade not required' || die 'should not have upgraded'
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,86 @@ The "next" branch may be rebased on master occasionally and will be used in the 
 
 ### Testing Changes
 
-To build, you can use [docker build](https://docs.docker.com/engine/reference/commandline/build/), [buildah bud](https://buildah.io/), [podman build](http://docs.podman.io/en/latest/markdown/podman-build.1.html) or any other container tool that understands Dockerfiles. The only argument needed is the build directory (10.X).
+To build, you can use [docker build](https://docs.docker.com/engine/reference/commandline/build/), [buildah bud](https://buildah.io/), [podman build](http://docs.podman.io/en/latest/markdown/podman-build.1.html) or any other container tool that understands Dockerfiles.
 
-Run:
+Run all tests:
 ```
-.test/run {container hash/tag}
+.test/run.sh <container hash/tag>
 ```
 
-This will run through all current tests and the new tests you have created. The key aspect is that the script should error returning a non-zero exit code if the test fails.
+Run a single test by name (without the `test_` prefix):
+```
+.test/run.sh <image> <test_name>
+```
+
+List all available tests:
+```
+.test/run.sh <image> --list
+```
+
+Use `-v` / `--verbose` for full trace output.
+
+The key aspect is that the script should error returning a non-zero exit code if the test fails.
+
+#### Adding a New Test
+
+The test suite lives under `.test/` with the following structure:
+
+| Path | Purpose |
+|------|---------|
+| `run.sh` | Test runner; defines `TEST_ORDER` (the list and execution order of all tests) |
+| `lib.sh` | Shared helper functions sourced by the runner |
+| `tests/*.sh` | Test files containing `test_*` functions, grouped by topic |
+| `initdb.d/` | SQL / shell scripts used by init tests |
+| `encryption/`, `encryption_conf/`, `initenc/` | Fixtures for encryption tests |
+| `tls/` | TLS configuration fixtures |
+
+To add a new test, follow these steps:
+
+1. **Create the test function** — add a `test_<name>` function in the appropriate file under `.test/tests/` (or create a new `.sh` file if your test covers a new topic). Each file is sourced by `run.sh` automatically. Include a header comment and do not make the file executable on its own:
+
+```bash
+#!/bin/bash
+# Tests for <topic>
+# Sourced by run.sh — do not execute directly
+
+test_my_new_feature() {
+	echo -e "Test: description of what is being tested\n"
+
+	runandwait -e MARIADB_ROOT_PASSWORD=secret "${image}"
+	result=$(mariadbclient -u root -psecret -e 'SELECT 1')
+	[ "$result" = "1" ] || die "expected 1, got $result"
+	killoff
+}
+```
+
+2. **Register the test** — append your test name (without the `test_` prefix) to the `TEST_ORDER` array in `.test/run.sh`:
+
+```bash
+TEST_ORDER=(
+	# ... existing tests ...
+	my_new_feature
+)
+```
+
+3. **Add supporting files** if needed — place SQL scripts, config files, or other fixtures in the appropriate `.test/` subdirectory (e.g. `initdb.d/`, `tls/`).
+
+#### Key Helper Functions (from `lib.sh`)
+
+| Function | Description |
+|----------|-------------|
+| `runandwait [-e ENV=val ...] <image> [args]` | Start a container and wait until MariaDB is accepting connections. Sets the global `$cid` variable. |
+| `killoff` | Stop and remove the current container (and any master/network). Always call this at the end of your test. |
+| `die <message>` | Print container logs for debugging, clean up, and exit with an error. Use this for assertion failures. |
+| `mariadbclient [args]` | Run the `mariadb` client inside the running container (via socket). |
+| `mariadbclient_tcp [args]` | Run the `mariadb` client inside the running container over TCP (`--protocol tcp`). |
+
+#### Tips
+
+* Tests must be self-contained: start a container, verify, then `killoff`.
+* Use `die` for failures — it dumps container logs before exiting, making debugging easy.
+* To skip a test conditionally (e.g. architecture-specific), `echo` a skip message and `return 0`.
+* If your test needs additional system dependencies, check for their existence and skip gracefully if they are not available.
 
 ### Git Commits
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ TEST_ORDER=(
 * Use `die` for failures — it dumps container logs before exiting, making debugging easy.
 * To skip a test conditionally (e.g. architecture-specific), `echo` a skip message and `return 0`.
 * If your test needs additional system dependencies, check for their existence and skip gracefully if they are not available.
+* Use [shellcheck](https://github.com/koalaman/shellcheck) to avoid code smells.
 
 ### Git Commits
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Run all tests:
 
 Run a single test by name (without the `test_` prefix):
 ```
-.test/run.sh <image> <test_name>
+.test/run.sh <image> <test_name...>
 ```
 
 List all available tests:
 ```
-.test/run.sh --list <image>
+.test/run.sh --list
 ```
 
 Use `-v` / `--verbose` for full trace output.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ To add a new test, follow these steps:
 #!/bin/bash
 # Tests for <topic>
 # Sourced by run.sh — do not execute directly
+# shellcheck disable=SC2154
 
 test_my_new_feature() {
 	echo -e "Test: description of what is being tested\n"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Run a single test by name (without the `test_` prefix):
 
 List all available tests:
 ```
-.test/run.sh <image> --list
+.test/run.sh --list <image>
 ```
 
 Use `-v` / `--verbose` for full trace output.


### PR DESCRIPTION
Hi there!

Yesterday, I contributed here and added a test to `run.sh`.
I found the experience a bit clunky.
To improve this, I’m proposing a refactor of the test runner.

As I understand the goal is to stick to shell scripts with zero dependencies, so I’ve kept that principle intact.
I reused the current architecture with a more maintainable core, and simplified the default output to make it less verbose.

The goal is also to achieve a cleaner separation of concerns by grouping tests into distinct files and named functions based on their categories.

How it works:

- By default, simple output like :
```bash
❯ ./run_new.sh mariadb:new_feature                             
=> required_password                             PASSED
=> mariadb_user_host                             PASSED
══════════════════════════════════════════════════════════════
 Results: 2 passed, 0 failed
══════════════════════════════════════════════════════════════
```

- When a test crashes, the output and stack traces are displayed :
```bash
❯ ./run_new.sh mariadb:11.4                                    
=> required_password                             PASSED
=> mariadb_user_host                             FAILED
 test output 
+ test_mariadb_user_host
+ echo -e 'Test: MARIADB_USER_HOST makes user host configurable at init\n'
Test: MARIADB_USER_HOST makes user host configurable at init

...(I won't put the entire trace here lol)
```

- When the -v flag is passed, you get the full verbose output as before :
```bash
❯ ./run_new.sh -v mariadb:new_feature
+ passed=0
+ failed=0
+ skipped=0
++ mktemp
+ test_logfile=/tmp/tmp.CX28KzmqMD
+ trap 'rm -f "$test_logfile"; killoff' EXIT
+ '[' -n '' ']'
+ for t in "${TEST_ORDER[@]}"
+ validate_test required_password
+ local name=required_password
+ declare -f test_required_password
+ run_test required_password
+ local name=required_password
+ cname=
+ cid=
+ '[' 1 -eq 1 ']'
+ echo ''

+ echo '=> Running: required_password'
=> Running: required_password
+ echo ''

...
```

I’m setting this PR to Draft for now as I’d like to polish it later, but I’d love to hear what you think!

Thanks! :)